### PR TITLE
feat: add arrowspace spectral vector search skill

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -1,8 +1,8 @@
 # Skill Catalog
 
-Generated at: 2026-05-20T06:48:40.204Z
+Generated at: 2026-06-30T17:15:47.021Z
 
-Total skills: 794
+Total skills: 795
 
 ## architecture (64)
 
@@ -116,7 +116,7 @@ Total skills: 794
 | `startup-financial-modeling` | This skill should be used when the user asks to "create financial projections", "build a financial model", "forecast revenue", "calculate burn rate", "estima... | startup, financial, modeling | startup, financial, modeling, skill, should, used, user, asks, projections, model, forecast, revenue |
 | `team-composition-analysis` | This skill should be used when the user asks to "plan team structure", "determine hiring needs", "design org chart", "calculate compensation", "plan equity a... | team, composition | team, composition, analysis, skill, should, used, user, asks, plan, structure, determine, hiring |
 
-## data-ai (179)
+## data-ai (180)
 
 | Skill | Description | Tags | Triggers |
 | --- | --- | --- | --- |
@@ -135,6 +135,7 @@ Total skills: 794
 | `anndata` | Data structure for annotated matrices in single-cell analysis. Use when working with .h5ad files or integrating with the scverse ecosystem. This is the data ... | anndata | anndata, data, structure, annotated, matrices, single, cell, analysis, working, h5ad, files, integrating |
 | `api-documenter` | Master API documentation with OpenAPI 3.1, AI-powered tools, and modern developer experience practices. Create interactive docs, generate SDKs, and build com... | api, documenter | api, documenter, documentation, openapi, ai, powered, developer, experience, interactive, docs, generate, sdks |
 | `arboreto` | Infer gene regulatory networks (GRNs) from gene expression data using scalable algorithms (GRNBoost2, GENIE3). Use when analyzing transcriptomics data (bulk ... | arboreto | arboreto, infer, gene, regulatory, networks, grns, expression, data, scalable, algorithms, grnboost2, genie3 |
+| `arrowspace` | Spectral vector search using graph Laplacian eigenstructure. Use when cosine/L2 similarity misses latent structure, or you need λτ-indexed retrieval with spe... | arrowspace | arrowspace, spectral, vector, search, graph, laplacian, eigenstructure, cosine, l2, similarity, misses, latent |
 | `astropy` | Comprehensive Python library for astronomy and astrophysics. This skill should be used when working with astronomical data including celestial coordinates, p... | astropy | astropy, python, library, astronomy, astrophysics, skill, should, used, working, astronomical, data, including |
 | `autonomous-agent-patterns` | Design patterns for building autonomous coding agents. Covers tool integration, permission systems, browser automation, and human-in-the-loop workflows. Use ... | autonomous, agent | autonomous, agent, building, coding, agents, covers, integration, permission, browser, automation, human, loop |
 | `autonomous-agents` | Autonomous agents are AI systems that can independently decompose goals, plan actions, execute tools, and self-correct without constant human guidance. The c... | autonomous, agents | autonomous, agents, ai, independently, decompose, goals, plan, actions, execute, self, correct, without |

--- a/data/aliases.json
+++ b/data/aliases.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-20T06:48:40.204Z",
+  "generatedAt": "2026-06-30T17:15:47.021Z",
   "aliases": {
     "accessibility-compliance-audit": "accessibility-compliance-accessibility-audit",
     "active directory attacks": "active-directory-attacks",

--- a/data/bundles.json
+++ b/data/bundles.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-20T06:48:40.204Z",
+  "generatedAt": "2026-06-30T17:15:47.021Z",
   "bundles": {
     "core-dev": {
       "description": "Core development skills across languages, frameworks, and backend/frontend fundamentals.",

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-20T06:48:40.204Z",
-  "total": 794,
+  "generatedAt": "2026-06-30T17:15:47.021Z",
+  "total": 795,
   "skills": [
     {
       "id": "3d-web-experience",
@@ -1252,6 +1252,30 @@
         "teensy"
       ],
       "path": "skills/arm-cortex-expert/SKILL.md"
+    },
+    {
+      "id": "arrowspace",
+      "name": "arrowspace",
+      "description": "Spectral vector search using graph Laplacian eigenstructure. Use when cosine/L2 similarity misses latent structure, or you need λτ-indexed retrieval with spectral awareness.",
+      "category": "data-ai",
+      "tags": [
+        "arrowspace"
+      ],
+      "triggers": [
+        "arrowspace",
+        "spectral",
+        "vector",
+        "search",
+        "graph",
+        "laplacian",
+        "eigenstructure",
+        "cosine",
+        "l2",
+        "similarity",
+        "misses",
+        "latent"
+      ],
+      "path": "skills/arrowspace/SKILL.md"
     },
     {
       "id": "astropy",

--- a/skills/arrowspace/SKILL.md
+++ b/skills/arrowspace/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: arrowspace
+description: "Spectral vector search using graph Laplacian eigenstructure. Use when cosine/L2 similarity misses latent structure, or you need λτ-indexed retrieval with spectral awareness."
+risk: safe
+source: self
+---
+
+# ArrowSpace
+
+Spectral vector search that augments nearest-neighbour search with graph Laplacian features. Computes a Laplacian over the item graph and uses the Rayleigh quotient to produce a λτ (lambda-tau) score per item, enabling search that respects both semantic similarity and structural role.
+
+## Use this skill when
+
+- Cosine or L2 similarity misses latent structure in your embeddings
+- You want graph-based retrieval with spectral awareness
+- You need to characterise the spectral properties of an embedding space
+- You are building RAG pipelines where contextual role matters alongside semantic content
+
+## Do not use this skill when
+
+- Pure cosine or L2 similarity is sufficient
+- Your dataset has fewer than 10 items (graph structure is not meaningful)
+- You need real-time indexing of streaming data (ArrowSpace is batch-oriented)
+
+## Installation
+
+```bash
+pip install arrowspace
+```
+
+## Quick Start
+
+```python
+from arrowspace import ArrowSpaceBuilder
+import numpy as np
+
+items = np.array([[0.1, 0.2, 0.3],
+                  [0.0, 0.5, 0.1],
+                  [0.9, 0.1, 0.0]], dtype=np.float64)
+
+graph_params = {"eps": 1.0, "k": 6, "topk": 3, "p": 2.0, "sigma": 1.0}
+builder = ArrowSpaceBuilder(items, graph_params=graph_params)
+aspace = builder.build()
+lambdas = aspace.lambdas()
+```
+
+## Instructions
+
+1. Install `arrowspace` via pip.
+2. Prepare your embedding vectors as an (N, d) NumPy array of `float64`.
+3. Configure `graph_params`: `eps` (neighbourhood radius), `k` (graph degree), `p` (Minkowski norm), `sigma` (Gaussian kernel width), `topk` (retrieval count).
+4. Call `ArrowSpaceBuilder(items, graph_params).build()` to construct the spectral space.
+5. Query with `aspace.lambdas()` (array indexed by insertion order) or `aspace.lambdas_sorted()` (sorted by score ascending).
+6. Higher λτ values indicate items that are both semantically close to the query and structurally central in the graph.
+
+## Best Practices
+
+- Normalise embeddings to unit norm before passing to ArrowSpace (the builder does this internally, but pre-normalising helps with graph construction).
+- Start with `eps` proportional to `1 / sqrt(dim)` and tune from there.
+- Use `k` between 3 and 25 depending on dataset size (rule of thumb: N / 50).
+- Set `sigma = None` to auto-select kernel width based on distance distribution.
+
+## Related Skills
+
+- `vector-database-engineer` — General vector database expertise
+- `embedding-strategies` — Embedding model selection and chunking
+- `similarity-search-patterns` — Semantic search implementation patterns
+- `hybrid-search-implementation` — Combined semantic + keyword search

--- a/skills_index.json
+++ b/skills_index.json
@@ -459,6 +459,15 @@
     "source": "unknown"
   },
   {
+    "id": "arrowspace",
+    "path": "skills/arrowspace",
+    "category": "uncategorized",
+    "name": "arrowspace",
+    "description": "Spectral vector search using graph Laplacian eigenstructure. Use when cosine/L2 similarity misses latent structure, or you need \u03bb\u03c4-indexed retrieval with spectral awareness.",
+    "risk": "safe",
+    "source": "self"
+  },
+  {
     "id": "astropy",
     "path": "skills/astropy",
     "category": "uncategorized",


### PR DESCRIPTION
## Summary

Add ArrowSpace — a spectral vector search skill using graph Laplacian eigenstructure for λτ-indexed retrieval.

- What: ArrowSpace augments nearest-neighbour search with spectral awareness via graph Laplacian analysis.
- Why: Enables search that respects both semantic similarity and structural role in the dataset — useful for RAG pipelines, embeddings analysis, and scientific research.

## Checklist
- [x] name matches folder name
- [x] description in frontmatter
- [x] Use this skill when / Do not use sections
- [x] risk: safe
- [ ] PR targets main branch