### PR TITLE
feat: add sendmux skills

### DIFF
--- a/skills/sendmux-cli/SKILL.md
+++ b/skills/sendmux-cli/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: sendmux-cli
+description: "Use the Sendmux CLI for profiles, key-scope checks, JSON output, and generated operation commands."
+risk: critical
+source: https://github.com/Sendmux/skills/tree/main/skills/sendmux-cli
+---
+
+# Sendmux CLI
+
+Use this skill when the terminal is the right Sendmux surface.
+
+## When to Use This Skill
+
+- Use when the terminal is the right Sendmux surface.
+- Use when the user needs exact sendmux CLI install, profile, flag, or generated operation command syntax.
+- Use when preflighting key scope or producing machine-readable --json output.
+
+## Copy-Paste Example
+
+```text
+sendmux mailbox:search-message-snippets --profile mailbox --query q=invoice --query limit=10 --json
+```
+
+## Boundaries
+
+- Do not ask the user to paste API keys.
+- Use `smx_root_` keys only for `management:*` commands.
+- Use `smx_mbx_` keys or scoped `smx_agent_` tokens for `mailbox:*` commands.
+- Use a send-capable `smx_mbx_` key or owner-approved Sending-resource `smx_agent_` token for `sending:*` commands. Pre-claim `smx_agent_` tokens cannot send.
+- Do not run destructive commands without explicit confirmation.
+- Use `--json` for agent-readable output.
+- Prefer task-specific Sendmux skills when the user needs strategy; use this skill for exact CLI mechanics.
+
+## Install
+
+```bash
+npm install -g @sendmux/cli
+sendmux --help
+```
+
+The package exposes the `sendmux` binary.
+Use the latest CLI before using `smx_agent_` tokens; older installs may reject that prefix before sending a request.
+
+## Profiles
+
+Create separate profiles for root and mailbox keys.
+
+```bash
+sendmux profiles:set default --api-key "$SENDMUX_ROOT_KEY" --default --json
+sendmux profiles:set mailbox --api-key "$SENDMUX_MBX_KEY" --json
+sendmux profiles:set sending --api-key "$SENDMUX_MBX_KEY" --json
+sendmux profiles:list --json
+sendmux profiles:show default --json
+```
+
+Profile reads mask stored keys. `profiles:set` reports `key_kind` as `root` or `mailbox`.
+
+Authentication resolution:
+
+1. `--api-key`, then `SENDMUX_API_KEY`.
+2. If no direct key is present, `--profile` / `-p`, then `SENDMUX_PROFILE`, then the configured default profile.
+3. Base URL comes from `--base-url`, then `SENDMUX_BASE_URL`, then the selected profile.
+
+## Preflight
+
+The CLI infers key kind from the prefix before sending a request.
+
+| Command surface | Required key                                                                      |
+| --------------- | --------------------------------------------------------------------------------- |
+| `management:*`  | `smx_root_`                                                                       |
+| `mailbox:*`     | `smx_mbx_` or scoped `smx_agent_`                                                 |
+| `sending:*`     | Send-capable `smx_mbx_` key or owner-approved Sending-resource `smx_agent_` token |
+
+Wrong-key examples fail before network:
+
+```text
+Command requires a root API key, but --api-key contains a mailbox API key.
+Command requires a send-capable `smx_mbx_` key or owner-approved Sending-resource `smx_agent_` token, but --api-key contains a root API key.
+```
+
+## Command catalogue
+
+The CLI exposes generated operation commands:
+
+| Surface    | Count | Examples                                                                                                                                                   |
+| ---------- | ----: | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Management |    52 | `management:domains:list`, `management:create-domain`, `management:create-mailbox`, `management:get-spend-summary`, `management:create-webhook`            |
+| Mailbox    |    40 | `mailbox:search-message-snippets`, `mailbox:batch-get-messages`, `mailbox:query-message-changes`, `mailbox:send-message`, `mailbox:list-granted-mailboxes` |
+| Sending    |     3 | `sending:get-open-api-spec`, `sending:send`, `sending:send:batch`                                                                                          |
+| Profiles   |     3 | `profiles:list`, `profiles:set`, `profiles:show`                                                                                                           |
+
+Use command-level help to discover accepted path, query, header, and body fields:
+
+```bash
+sendmux management:create-domain --help
+sendmux mailbox:search-message-snippets --help
+sendmux sending:send:batch --help
+```
+
+## Operation flags
+
+Operation commands share these flags:
+
+| Flag                  | Use                                                                        |
+| --------------------- | -------------------------------------------------------------------------- |
+| `--api-key`           | Direct key; overrides profile/env profile lookup.                          |
+| `--base-url`          | Override API base URL.                                                     |
+| `--profile`, `-p`     | Select a local profile.                                                    |
+| `--body`              | Inline JSON request body, or text bytes for byte-oriented operations.      |
+| `--body-file`         | Read a JSON request body or byte payload from a file.                      |
+| `--path name=value`   | Path parameters. Repeat for multiple path params.                          |
+| `--query name=value`  | Query parameters. Repeat for filters and pagination.                       |
+| `--header name=value` | Headers accepted by the operation. Repeat for multiple headers.            |
+| `--idempotency-key`   | Shortcut for `Idempotency-Key`. Works only when the operation supports it. |
+| `--if-match`          | Shortcut for `If-Match`. Works only when the operation supports it.        |
+| `--if-none-match`     | Shortcut for `If-None-Match`. Works only when the operation supports it.   |
+| `--json`              | Machine-readable output.                                                   |
+
+`--path`, `--query`, and `--header` require `name=value`. Booleans use `true` or `false`. Repeat an array-valued parameter rather than comma-joining it.
+
+Pass either `--body` or `--body-file`, not both.
+
+## Examples
+
+Create a domain:
+
+```bash
+sendmux management:create-domain \
+  --profile default \
+  --idempotency-key "$IDEMPOTENCY_KEY" \
+  --body '{"domain":"example.com","mode":"send_receive"}' \
+  --json
+```
+
+Get domain DNS records:
+
+```bash
+sendmux management:get-domain-zone-file \
+  --profile default \
+  --path public_id=mdom_abc \
+  --json
+```
+
+Search a mailbox without reading full messages:
+
+```bash
+sendmux mailbox:search-message-snippets \
+  --profile mailbox \
+  --query q=invoice \
+  --query is_unread=true \
+  --query limit=10 \
+  --json
+```
+
+Batch-read selected mailbox messages:
+
+```bash
+sendmux mailbox:batch-get-messages \
+  --profile mailbox \
+  --body '{
+    "ids": ["eml_abc", "eml_def"],
+    "body_mode": "clean_json",
+    "max_body_chars": 4000
+  }' \
+  --json
+```
+
+Send a batch:
+
+```bash
+sendmux sending:send:batch \
+  --profile sending \
+  --idempotency-key "$IDEMPOTENCY_KEY" \
+  --body-file ./messages.json \
+  --json
+```
+
+Poll one unchanged-safe delivery log:
+
+```bash
+sendmux management:get-email-log \
+  --profile default \
+  --path public_id=dlog_abc \
+  --if-none-match "$ETAG" \
+  --json
+```
+
+## Routing
+
+- First setup/auth check: `sendmux-getting-started`.
+- Sending strategy and body shape: `sendmux-send-email`.
+- Mailbox read, search, sync, triage, or reply: `sendmux-mailbox-agent`.
+- Account-level management strategy: `sendmux-management`.
+- MCP connection setup: `sendmux-mcp-setup`.
+- Cheapest-call doctrine: `sendmux-token-efficient-usage`.
+
+## Limitations
+
+- Does not replace task-specific strategy skills such as sendmux-send-email, sendmux-mailbox-agent, or sendmux-management.
+- Does not run destructive commands without explicit confirmation.
+- Requires the correct key prefix for the chosen command surface.

--- a/skills/sendmux-email-for-agents/SKILL.md
+++ b/skills/sendmux-email-for-agents/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: sendmux-email-for-agents
+description: "Route agent email workflows across Sendmux setup, self-registration, mailbox runtime, sending, and approval."
+risk: critical
+source: https://github.com/Sendmux/skills/tree/main/skills/sendmux-email-for-agents
+---
+
+# Sendmux email for agents
+
+Use this skill when the user describes the agent-email problem: an AI agent needs an inbox, mailbox identity, outbound email, triage loop, reply workflow, or human approval path.
+
+## When to Use This Skill
+
+- Use when an AI agent needs its own inbox, mailbox identity, outbound email, triage loop, reply workflow, or human approval path.
+- Use when routing a Sendmux agent-email task across management, MCP setup, mailbox runtime, sending, CLI, or token-efficient usage skills.
+- Use even when the user describes the agent-email problem without naming Sendmux.
+
+## Copy-Paste Example
+
+```text
+User: "Give my support agent its own Sendmux inbox, connect it through MCP, and require approval before replies are sent."
+```
+
+## First route
+
+| User problem                               | Route                                                                                                                                                       |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Give my agent an email address"           | `sendmux-management` to create/inspect domain, mailbox, and mailbox key.                                                                                    |
+| "Let my agent register itself"             | Agent access: read `/auth.md`, optionally install skills with `npx skills add Sendmux/skills`, register at `identity_endpoint` with `proof_of_work`, immediately save the returned `claim_token` and agent credential bundle securely before token exchange, exchange the assertion, keep the assertion or pre-claim token until invite `202`, verify `/api/v1/mailbox/me`, then invite the owner or ask for the owner email. |
+| "Connect my agent to its inbox"            | `sendmux-mcp-setup` for agent MCP, or `sendmux-getting-started` for first auth checks.                                                                      |
+| "Read, search, triage, label, sync, reply" | `sendmux-mailbox-agent` with an `smx_mbx_*` key or scoped `smx_agent_*` token.                                                                              |
+| "Send independent outbound notifications"  | `sendmux-send-email` with a send-capable `smx_mbx_*` key or owner-approved Sending-resource `smx_agent_*` token; batch when there is more than one message. |
+| "Build this into an app or worker"         | SDK path from the task skill; use `sendmux-token-efficient-usage` for call minimisation.                                                                    |
+| "Show terminal commands"                   | `sendmux-cli`.                                                                                                                                              |
+
+If the task crosses setup and runtime, split it:
+
+1. `sendmux-management` provisions the mailbox and mailbox API key with an `smx_root_*` key.
+2. Runtime agent work uses the new `smx_mbx_*` key.
+3. `sendmux-mcp-setup` connects the agent if the client supports MCP.
+4. `sendmux-mailbox-agent` handles ongoing mailbox read/triage/reply.
+
+For self-registration without a human-created key, use agent access instead:
+
+1. Read `https://app.sendmux.ai/auth.md`.
+2. Use the copy-paste proof helper in `/auth.md` if the agent needs exact solver code.
+3. Send the intended anonymous registration body to `POST /agent-auth/agent/identity/challenge`.
+4. Solve the returned proof-of-work challenge.
+5. Encode `proof_of_work` as base64 UTF-8 JSON with `{ "challenge": <exact challenge>, "solution": { "counter": <integer>, "derivedKey": <hex> } }`.
+6. Create the anonymous identity with the same body plus `proof_of_work` at `identity_endpoint`, `POST /agent-auth/agent/identity`.
+7. Immediately save the returned `claim_token` and agent credential bundle in a secure store before token exchange, then exchange the returned `identity_assertion` at `POST /agent-auth/oauth2/token`.
+8. Call `GET /api/v1/mailbox/me` with the returned pre-claim `smx_agent_*` token.
+9. Keep the `identity_assertion` or pre-claim token available until the owner invite returns `202`; `claim_token` cannot create the invite.
+10. Do not stop after the pre-claim token works. If the owner email is known, request the owner invite with `POST /agent-auth/agent/identity/invite`. If it is unknown, ask: `What owner email should I invite for approval?`
+11. After the owner accepts and approves sending in Sendmux, exchange `claim_token` with the claim grant for an app-resource or Sending-resource `smx_agent_*` token.
+
+## Safety boundaries
+
+- Do not ask the user to paste API keys, mailbox keys, OAuth tokens, or one-time secrets.
+- Store the self-registration credential bundle in a secure store immediately after registration; later MCP, CLI, SDK, mailbox, and sending work depends on it.
+- Never rely on chat, logs, repo files, screenshots, or memory-only state for `claim_token` or agent credentials.
+- Keep the `identity_assertion` or pre-claim `smx_agent_*` token available until the owner invite returns `202`. If both are lost before the invite succeeds, register a fresh identity and invite immediately.
+- Do not poll the claim-token grant before the owner invite returns `202`; after `202`, polling with `claim_token` is the wait-for-approval path. `claim_token` cannot create the owner invite.
+- Do not send email until the user has supplied or confirmed the recipient, subject, body, and attachments.
+- Treat "draft for approval" as a draft. Ask for explicit approval before calling `mailbox_send_message`, `sending_send_email`, or `sending_send_email_batch`.
+- Use separate scopes: `smx_root_*` for provisioning/admin, send-capable `smx_mbx_*` keys or owner-approved Sending-resource `smx_agent_*` tokens for Sending, `smx_mbx_*` keys for normal Mailbox runtime, and `smx_agent_*` only for the scopes it was issued with.
+- Do not use a root key inside an agent that only needs mailbox read/send work.
+- Pre-claim `smx_agent_*` tokens include `mailbox.read` and `email.receive`, not `email.send`.
+- Owner invites are sent by Sendmux through the invite endpoint. Do not route them through the Sending API.
+- Only one live pre-claim owner invite can be pending; retry the same request with the same idempotency key.
+- Token exchange can return expected `503` states while mailbox provisioning or owner approval is pending. Wait for `Retry-After` or `retry_after`. Registration `503 server_error` means stop and report, not repeated retries.
+- Agent-auth `429` responses include retry timing; wait for `Retry-After` or `retry_after` before trying again.
+- Confirm destructive mailbox actions before delete, permanent delete, key revocation, suspend, or resume.
+
+## Workflow patterns
+
+### New agent inbox
+
+Use when the user wants a new mailbox for an agent, such as support intake, invoice triage, scheduling, approvals, or lead qualification.
+
+Plan:
+
+1. Domain and mailbox setup: route to `sendmux-management`.
+2. Mailbox key: create a mailbox-scoped key for the agent runtime.
+3. Connection: route to `sendmux-mcp-setup` if the agent client can use MCP; otherwise use CLI or SDK.
+4. First harmless check: `mailbox_get_me`, CLI `mailbox:me:get`, or SDK `mailboxGetMe`.
+5. Runtime loop: route read/search/sync/reply tasks to `sendmux-mailbox-agent`.
+
+Mention that DNS/domain setup may be required before a custom address receives mail.
+
+### Self-registered agent inbox
+
+Use when the user wants the agent to start without a human-created API key.
+
+Plan:
+
+1. Read discovery from `https://app.sendmux.ai/auth.md`.
+2. Use the copy-paste proof helper in `/auth.md` if exact solver code is needed.
+3. Request a registration challenge at `/agent-auth/agent/identity/challenge` with the intended anonymous registration body.
+4. Solve the returned challenge.
+5. Encode `proof_of_work` as base64 UTF-8 JSON with `{ "challenge": <exact challenge>, "solution": { "counter": <integer>, "derivedKey": <hex> } }`.
+6. Create the anonymous identity at `identity_endpoint`, `/agent-auth/agent/identity`, with the same body plus `proof_of_work`.
+7. Immediately save the returned `claim_token` and agent credential bundle in a secure store before token exchange, then exchange `identity_assertion` at `/agent-auth/oauth2/token`.
+8. Call `/api/v1/mailbox/me` with the pre-claim `smx_agent_*` token.
+9. Keep the `identity_assertion` or pre-claim token available until the owner invite returns `202`; `claim_token` cannot create the invite.
+10. Do not stop after the pre-claim token works. If the owner email is known, request an owner invite at `/agent-auth/agent/identity/invite`. If it is unknown, ask: `What owner email should I invite for approval?`
+11. After owner approval, exchange `claim_token` at `/agent-auth/oauth2/token` with Sendmux's documented claim grant; request `resource=https://smtp.sendmux.ai/api/v1` before Sending API calls.
+
+Do not say the pre-claim agent can send email. It cannot. After owner approval, a Sending-resource claim-grant `smx_agent_*` token can send from the assigned mailbox. Sendmux sends the owner invite email separately. Only one live pre-claim owner invite can be pending; retry the same request with the same idempotency key. On expected token-exchange `503` states, wait for `Retry-After` or `retry_after`. On registration `503 server_error`, stop and report the failure. On `429`, wait for `Retry-After` or `retry_after`.
+
+The raw `claim_token` is shown once and is required after owner approval. Sendmux cannot recover it later. Immediately after registration, store the agent credential bundle: `claim_token`, `registration_id`, `mailbox.email`, `claim_token_expires`, `identity_assertion`, `token_endpoint`, the app resource URL, and the sending resource URL. Use a secure store such as 1Password, an OS keychain, or the agent platform's encrypted secret store. After token exchange, add the pre-claim token or keep `identity_assertion` available until invite `202`. If no secure store is available, stop and ask the user where to store the bundle before sending the owner invite. If the claim token was lost, rerun registration and invite with a fresh agent identity. If the `identity_assertion` and pre-claim token were lost before the invite returned `202`, rerun registration and invite immediately in the same flow.
+
+### Agent triage loop
+
+Use mailbox-efficient calls:
+
+1. `mailbox_get_changes` or query-change endpoints to resume from the prior state.
+2. `mailbox_count_messages` for counts.
+3. `mailbox_search_message_snippets` with small `limit` for candidate messages.
+4. `mailbox_batch_get_messages` for selected IDs.
+5. `mailbox_batch_update_messages` only after the user confirms labels, flags, or read-state changes.
+
+Store state tokens. Do not rescan the whole mailbox.
+
+### Human-approved replies
+
+Use when the agent should prepare a reply but a person approves the send.
+
+Plan:
+
+1. Use `sendmux-mailbox-agent` to read the relevant message or thread.
+2. Produce the draft text and list the target message/thread.
+3. Ask for approval with the exact recipient, subject, and body.
+4. After approval, send with `mailbox_send_message` for mailbox-centred replies.
+5. Use `Idempotency-Key` for retryable sends.
+
+### Outbound notifications
+
+Use `sendmux-send-email` when the email is not a reply inside an active mailbox workflow.
+
+- One message: `sending_send_email`, CLI `sending:send`, or SDK `sendingSendEmail`.
+- More than one message: `sending_send_email_batch`, CLI `sending:send:batch`, or SDK `sendingSendEmailBatch`.
+- Use `Idempotency-Key` and inspect per-message batch results.
+
+## Output shape
+
+When designing a workflow, answer in this order:
+
+1. **Recommended route:** name the Sendmux skill(s) to use next.
+2. **Key scope:** `smx_root_*` for admin, `smx_mbx_*` for normal runtime, `smx_agent_*` for scoped self-registered agent runtime, and owner-approved Sending-resource `smx_agent_*` for agent sending.
+3. **Runtime surface:** MCP when curated and connected, CLI for terminal work, SDK for application code.
+4. **Core calls:** list the smallest Sendmux calls needed.
+5. **Human approval:** state what must be confirmed before sending or mutating mail.
+6. **Efficiency:** name the batch, snippet, count, delta, cursor, ETag, or idempotency pattern that avoids extra work.
+
+## Do not over-answer
+
+This is a router and architecture skill. Hand detailed implementation to the task skill once the route is clear:
+
+- `sendmux-management`: domains, mailbox provisioning, mailbox keys, account admin, webhooks, billing, logs.
+- `sendmux-mailbox-agent`: mailbox read/search/sync/triage/reply.
+- `sendmux-send-email`: send bodies, attachments, batch send, HTTP-vs-SMTP send choice.
+- `sendmux-mcp-setup`: client configuration and hosted/local MCP.
+- `sendmux-cli`: exact terminal commands and flags.
+- `sendmux-token-efficient-usage`: cheapest-call doctrine across surfaces.
+
+## Limitations
+
+- This is a router and architecture skill; detailed implementation belongs in the task-specific Sendmux skills named by the source.
+- Does not send email or mutate mail without explicit human approval.
+- Cannot recover a lost claim_token; the source says rerun registration and invite with a fresh agent identity.

--- a/skills/sendmux-getting-started/SKILL.md
+++ b/skills/sendmux-getting-started/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: sendmux-getting-started
+description: "Set up Sendmux, choose key scopes, verify first harmless calls, and route agent registration."
+risk: critical
+source: https://github.com/Sendmux/skills/tree/main/skills/sendmux-getting-started
+---
+
+# Sendmux getting started
+
+Use this skill to get a user from "I have a Sendmux task" to the correct surface, key kind, package, and first verified call.
+
+## When to Use This Skill
+
+- Use when setting up Sendmux tools, skills, keys, or first verification calls.
+- Use when choosing between MCP, CLI, SDK, or direct HTTP for a Sendmux task.
+- Use when an agent needs Sendmux self-registration, owner invite, or credential-bundle handling.
+
+## Copy-Paste Example
+
+```text
+User: "Set up Sendmux for this agent and verify the mailbox key without sending email."
+```
+
+## Safety first
+
+- Do not ask the user to paste an API key.
+- Do not print API keys.
+- Prefer existing environment variables, local CLI profiles, or the user's secret manager.
+- Store the self-registration credential bundle in a secure store immediately after registration; later MCP, CLI, SDK, mailbox, and sending work depends on it.
+- Never rely on chat, logs, repo files, screenshots, or memory-only state for `claim_token` or agent credentials.
+- Keep the `identity_assertion` or pre-claim `smx_agent_*` token available until the owner invite returns `202`; `claim_token` is only for post-approval exchange.
+- If a key appears in chat or logs, stop and tell the user to rotate it before continuing.
+
+## Install Sendmux skills
+
+If the agent supports Skills and the Sendmux skills are not installed, install the pack first:
+
+```bash
+npx skills add Sendmux/skills
+```
+
+Skills are optional. If the agent cannot install skills, continue from `https://app.sendmux.ai/auth.md`.
+
+## Pick the key
+
+| Task                                                                                    | Key prefix                                                              | Start here                                                                                                               |
+| --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Send email through the Sending API                                                      | Send-capable `smx_mbx_` or owner-approved Sending-resource `smx_agent_` | `sendmux-send-email` for real sends; this skill can verify package/API discovery first.                                  |
+| Read, search, sync, triage, or reply from one mailbox                                   | `smx_mbx_` or scoped `smx_agent_`                                       | Mailbox MCP, CLI, or SDK.                                                                                                |
+| Manage domains, mailboxes, mailbox keys, providers, webhooks, logs, billing, or metrics | `smx_root_`                                                             | Management MCP, CLI, or SDK.                                                                                             |
+| Let an agent register itself and invite its owner                                       | No existing key, then `smx_agent_`                                      | Agent access: `/auth.md`, challenge endpoint, `identity_endpoint`, token endpoint, `/api/v1/mailbox/me`, and invite endpoint. |
+
+If the task mixes management and mailbox work, use separate keys and separate clients or profiles. Do not use a root key for mailbox-scoped examples.
+
+## Choose the surface
+
+1. Use MCP first when the user's agent already has the relevant `sendmux-mcp` server connected and the needed tool is curated.
+2. Use the `sendmux` CLI for one-shot terminal work, debugging, shell scripts, and examples the user can copy into a terminal. Add `--json` so downstream agents can parse the envelope.
+3. Use an SDK when writing application code. Install only the package for the chosen surface unless the project needs multiple surfaces.
+4. Use direct HTTP only when the user's environment cannot use MCP, CLI, or an SDK.
+
+## Install the relevant package
+
+CLI:
+
+```bash
+npm install -g @sendmux/cli
+```
+
+MCP:
+
+```bash
+pipx install sendmux-mcp
+```
+
+TypeScript SDK packages:
+
+```bash
+npm install @sendmux/mailbox
+npm install @sendmux/management
+npm install @sendmux/sending
+```
+
+Use the one package matching the task; do not install all three unless the project needs all three.
+
+## First verified calls
+
+### Mailbox key, mailbox work
+
+MCP tool:
+
+```text
+mailbox_get_me
+```
+
+CLI:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux profiles:set mailbox --default --json
+sendmux mailbox:me:get --json
+```
+
+SDK:
+
+```ts
+import { createMailboxClient, mailboxGetMe } from "@sendmux/mailbox";
+
+const client = createMailboxClient({ apiKey: process.env.SENDMUX_API_KEY! });
+const response = await mailboxGetMe({ client });
+console.log(response.data);
+```
+
+This call resolves the mailbox behind the bearer token and should be the default harmless first call for `smx_mbx_` and scoped `smx_agent_` mailbox workflows.
+
+### Self-registered agent token
+
+Use this when the agent has no human-created key yet.
+
+1. Read `https://app.sendmux.ai/auth.md`.
+2. Use the copy-paste proof helper in `/auth.md` if the agent needs exact solver code.
+3. Request a registration challenge with the intended anonymous registration body at `POST /agent-auth/agent/identity/challenge`.
+4. Solve the returned proof-of-work challenge.
+5. Encode `proof_of_work` as base64 UTF-8 JSON with `{ "challenge": <exact challenge>, "solution": { "counter": <integer>, "derivedKey": <hex> } }`.
+6. Create an anonymous identity with the same body plus `proof_of_work` at `identity_endpoint`, `POST /agent-auth/agent/identity`.
+7. Immediately save the returned `claim_token` and agent credential bundle in a secure store before token exchange, then exchange the returned `identity_assertion` with `POST /agent-auth/oauth2/token`.
+8. Call `GET /api/v1/mailbox/me` with the returned `smx_agent_` token.
+9. Keep the `identity_assertion` or pre-claim token available until the owner invite returns `202`; `claim_token` cannot create the invite.
+10. Do not stop after the pre-claim token works. If the owner email is known, request the owner invite with `POST /agent-auth/agent/identity/invite`. If it is unknown, ask: `What owner email should I invite for approval?`
+11. After the owner accepts and approves sending in Sendmux, exchange `claim_token` with the claim grant; request `resource=https://smtp.sendmux.ai/api/v1` before Sending API calls.
+
+Pre-claim `smx_agent_` tokens have `mailbox.read` and `email.receive`. They do not have `email.send`; owner-approved Sending-resource `smx_agent_` tokens can send from the assigned mailbox. Sendmux sends the owner invite through the invite endpoint. Only one live pre-claim owner invite can be pending; retry the same request with the same idempotency key. If token exchange returns expected `503` states, wait for `Retry-After` or `retry_after`. If registration returns `503 server_error`, stop and report it instead of looping. If agent auth returns `429`, wait for `Retry-After` or `retry_after` before retrying.
+
+The raw `claim_token` is shown once and is required after owner approval. Sendmux cannot recover it later. Immediately after registration, store the agent credential bundle: `claim_token`, `registration_id`, `mailbox.email`, `claim_token_expires`, `identity_assertion`, `token_endpoint`, the app resource URL, and the sending resource URL. Use a secure store such as 1Password, an OS keychain, or the agent platform's encrypted secret store. After token exchange, add the pre-claim token or keep `identity_assertion` available until invite `202`. If no secure store is available, stop and ask the user where to store the bundle before sending the owner invite. If the claim token was lost, rerun registration and invite with a fresh agent identity. If the `identity_assertion` and pre-claim token were lost before the invite returned `202`, rerun registration and invite immediately in the same flow.
+
+### Root key, management work
+
+MCP tool:
+
+```text
+management_list_mailboxes
+```
+
+CLI:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_ROOT_KEY" sendmux profiles:set root --default --json
+sendmux management:mailboxes:list --query limit=1 --json
+```
+
+SDK:
+
+```ts
+import {
+  createManagementClient,
+  managementListMailboxes,
+} from "@sendmux/management";
+
+const client = createManagementClient({ apiKey: process.env.SENDMUX_API_KEY! });
+const response = await managementListMailboxes({
+  client,
+  query: { limit: 1 },
+});
+console.log(response.data);
+```
+
+Use a small list call as the first management check. It verifies the root key and avoids creating or changing resources.
+
+### Sending work
+
+The Sending surface needs a send-capable `smx_mbx_` key with `email.send` or an owner-approved Sending-resource `smx_agent_` token. Do not send a real email as a health check unless the user explicitly asks to send one and provides the message details.
+
+CLI package/API discovery:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux sending:get-open-api-spec --json
+```
+
+SDK package/API discovery:
+
+```ts
+import { createSendingClient, sendingGetOpenApiSpec } from "@sendmux/sending";
+
+const client = createSendingClient({ apiKey: process.env.SENDMUX_API_KEY! });
+const response = await sendingGetOpenApiSpec({ client });
+console.log(response.data.info);
+```
+
+For a real send, route to `sendmux-send-email` and include an `Idempotency-Key`.
+
+## Interpret failures
+
+- Prefix error: the selected surface and credential do not match. Switch to `smx_mbx_` or scoped `smx_agent_` for Mailbox, a send-capable `smx_mbx_` key or owner-approved Sending-resource `smx_agent_` token for Sending, or `smx_root_` for Management.
+- `401`: key missing, invalid, or revoked.
+- `403`: key is valid but lacks the permission or surface required by the call.
+- `429` or `503`: retry according to the response headers; do not loop manually.
+- Empty list with `ok: true`: auth worked; there may be no resources yet.
+
+## Route after setup
+
+- Sending one or many outbound messages: `sendmux-send-email`.
+- Reading, searching, syncing, or replying from a mailbox: `sendmux-mailbox-agent`.
+- Managing domains, mailboxes, keys, webhooks, spend, logs, or metrics: `sendmux-management`.
+- CLI-specific workflows: `sendmux-cli`.
+- MCP client configuration: `sendmux-mcp-setup`.
+- Choosing the cheapest call pattern: `sendmux-token-efficient-usage`.
+
+## Limitations
+
+- Does not replace the live Sendmux auth discovery document at https://app.sendmux.ai/auth.md.
+- Cannot recover a lost claim_token; the source says rerun registration with a fresh agent identity.
+- Does not send real email as a health check unless the user explicitly asks and provides message details.

--- a/skills/sendmux-mailbox-agent/SKILL.md
+++ b/skills/sendmux-mailbox-agent/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: sendmux-mailbox-agent
+description: "Read, search, sync, triage, mutate, or reply from one Sendmux mailbox efficiently."
+risk: critical
+source: https://github.com/Sendmux/skills/tree/main/skills/sendmux-mailbox-agent
+---
+
+# Sendmux mailbox agent
+
+Use this skill for mailbox-scoped workflows with an `smx_mbx_` key or scoped `smx_agent_` token: read, search, triage, reply when allowed, and sync one mailbox.
+
+## When to Use This Skill
+
+- Use when reading, searching, counting, syncing, triaging, filing, deleting, threading, or replying from one Sendmux mailbox.
+- Use when the user has an smx_mbx_ key or scoped smx_agent_ token for mailbox runtime work.
+- Use when minimizing mailbox reads with count, snippet, batch-get, thread, folder, or sync calls.
+
+## Copy-Paste Example
+
+```text
+User: "Search the Sendmux mailbox for unread invoice messages, show snippets first, and ask before marking anything read."
+```
+
+## Boundaries
+
+- Do not ask the user to paste an API key.
+- Do not use a root key for mailbox work.
+- Do not create mailboxes or mailbox keys here; route those tasks to `sendmux-management`.
+- Do not delete or mutate messages without explicit user confirmation.
+- Treat pre-claim `smx_agent_` tokens as read/receive only. They do not have `email.send`; owner-approved app-resource `smx_agent_` tokens may send from their assigned mailbox when the token includes `email.send`.
+- If a credential grants more than one mailbox, include `mailbox_id` on mailbox calls; otherwise omit it.
+
+## Efficient defaults
+
+| Task                               | Preferred call                                                                                                |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Identify the mailbox               | `mailbox_get_me`, CLI `mailbox:me:get`, SDK `mailboxGetMe`.                                                   |
+| Count matching messages            | `mailbox_count_messages`, CLI `mailbox:count-messages`, SDK `mailboxCountMessages`.                           |
+| Search text                        | `mailbox_search_message_snippets`, CLI `mailbox:search-message-snippets`, SDK `mailboxSearchMessageSnippets`. |
+| Read known IDs                     | `mailbox_batch_get_messages`, CLI `mailbox:batch-get-messages`, SDK `mailboxBatchGetMessages`.                |
+| Mark, flag, or label many messages | `mailbox_batch_update_messages`, CLI `mailbox:batch-update-messages`, SDK `mailboxBatchUpdateMessages`.       |
+| Delete many messages               | `mailbox_batch_delete_messages`, CLI `mailbox:batch-delete-messages`, SDK `mailboxBatchDeleteMessages`.       |
+| Reply/send from this mailbox       | `mailbox_send_message`, CLI `mailbox:send-message`, SDK `mailboxSendMessage`.                                 |
+| Threads                            | `mailbox_list_threads`, `mailbox_get_thread`, `mailbox_list_thread_messages`.                                 |
+| Folders                            | `mailbox_list_folders`; inspect folders before filing or moving messages.                                     |
+| Broad sync                         | `mailbox_get_changes`, CLI `mailbox:get-changes`, SDK `mailboxGetChanges`.                                    |
+| Filtered message sync              | CLI/SDK `mailbox:query-message-changes` / `mailboxQueryMessageChanges`. MCP does not curate this yet.         |
+| Live mailbox events                | CLI/SDK `mailbox:stream-events` / `mailboxStreamEvents`. MCP does not curate this yet.                        |
+
+## Search before reading
+
+Use this sequence for most "find messages about X" tasks:
+
+1. Count first when the user asks "how many" or when a broad search may be large.
+2. Use search snippets with a small `limit`.
+3. Batch-get only the selected message IDs.
+4. Read clean body/content only for messages whose content matters.
+
+CLI:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux mailbox:count-messages \
+  --query q=invoice \
+  --query is_unread=true \
+  --json
+
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux mailbox:search-message-snippets \
+  --query q=invoice \
+  --query is_unread=true \
+  --query limit=10 \
+  --json
+
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux mailbox:batch-get-messages \
+  --body '{
+    "ids": ["eml_abc", "eml_def"],
+    "body_mode": "clean_json",
+    "max_body_chars": 4000,
+    "strip_quotes": true,
+    "strip_signature": true,
+    "include_attachments": "metadata"
+  }' \
+  --json
+```
+
+Use the same commands by putting a scoped `smx_agent_` token in `SENDMUX_API_KEY` when the operation is within its scopes.
+
+SDK:
+
+```ts
+import {
+  createMailboxClient,
+  mailboxBatchGetMessages,
+  mailboxCountMessages,
+  mailboxSearchMessageSnippets,
+} from "@sendmux/mailbox";
+
+const client = createMailboxClient({ apiKey: process.env.SENDMUX_API_KEY! });
+
+const count = await mailboxCountMessages({
+  client,
+  query: { q: "invoice", is_unread: true },
+});
+
+const snippets = await mailboxSearchMessageSnippets({
+  client,
+  query: { q: "invoice", is_unread: true, limit: 10 },
+});
+
+const messages = await mailboxBatchGetMessages({
+  client,
+  body: {
+    ids: snippets.data.snippets.map((item) => item.message_id),
+    body_mode: "clean_json",
+    max_body_chars: 4000,
+    strip_quotes: true,
+    strip_signature: true,
+    include_attachments: "metadata",
+  },
+});
+```
+
+## Triage and mutation
+
+Use batch mutations for more than one message. Get user confirmation first.
+
+Mark or label messages:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux mailbox:batch-update-messages \
+  --body '{
+    "ids": ["eml_abc", "eml_def"],
+    "seen": true,
+    "flagged": false,
+    "keywords": {
+      "agent_triaged": true,
+      "needs_reply": false
+    },
+    "if_in_state": "state_from_prior_read"
+  }' \
+  --json
+```
+
+Delete messages only after explicit confirmation:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux mailbox:batch-delete-messages \
+  --body '{
+    "ids": ["eml_abc", "eml_def"],
+    "permanent": false,
+    "if_in_state": "state_from_prior_read"
+  }' \
+  --json
+```
+
+`permanent: false` moves messages to Trash. Treat `permanent: true` as irreversible and ask for explicit confirmation.
+
+## Reply or send from the mailbox
+
+Before composing, read the identity:
+
+```text
+mailbox_get_identity
+```
+
+Then send from the authenticated mailbox. Use `Idempotency-Key` for retries.
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux mailbox:send-message \
+  --idempotency-key "$IDEMPOTENCY_KEY" \
+  --body '{
+    "to": [{ "email": "user@example.com", "name": null }],
+    "subject": "Re: Your message",
+    "html_body": "<p>Thanks for the update.</p>",
+    "text_body": "Thanks for the update."
+  }' \
+  --json
+```
+
+Mailbox send uses `to` as an array. `subject` and `to` are required. `from` is optional when sending from the authenticated mailbox identity.
+
+Attachments may be inline small files:
+
+```json
+{
+  "filename": "report.pdf",
+  "content_type": "application/pdf",
+  "content": "<<base64-content>>"
+}
+```
+
+or uploaded blobs:
+
+```json
+{
+  "filename": "report.pdf",
+  "content_type": "application/pdf",
+  "blob_id": "blob_..."
+}
+```
+
+## Threads and folders
+
+- Use `mailbox_list_threads` with small `limit` for conversation-level scanning.
+- Use `mailbox_get_thread` for one thread summary.
+- Use `mailbox_list_thread_messages` for message summaries in a known thread.
+- Use clean content/body tools only for selected messages or threads.
+- Use `mailbox_list_folders` before moving or filing messages.
+
+CLI examples:
+
+```bash
+sendmux mailbox:list-threads --query q=renewal --query limit=10 --json
+sendmux mailbox:list-thread-messages --path thread_id=thr_abc --query limit=20 --json
+sendmux mailbox:folders:list --query limit=100 --json
+```
+
+## Sync
+
+Use sync endpoints instead of re-listing the mailbox.
+
+Broad mailbox sync:
+
+```bash
+sendmux mailbox:get-changes \
+  --query types=messages,folders,threads \
+  --query messages_since_state="$MESSAGES_STATE" \
+  --query folders_since_state="$FOLDERS_STATE" \
+  --query threads_since_state="$THREADS_STATE" \
+  --query limit=100 \
+  --json
+```
+
+Filtered message-list sync:
+
+```bash
+sendmux mailbox:query-message-changes \
+  --query since_query_state="$QUERY_STATE" \
+  --query q=invoice \
+  --query is_unread=true \
+  --query calculate_total=true \
+  --query limit=100 \
+  --json
+```
+
+Store the returned new state token. Follow `has_more` with the same filters when more changes remain.
+
+## Error handling
+
+- `401`: missing, invalid, or revoked key.
+- `403`: wrong key surface or missing mailbox permission.
+- `404`: selected message, thread, or folder does not exist in this mailbox.
+- `409`: stale state or idempotency conflict; re-read state before mutating.
+- `429` or `503`: retry according to response headers.
+
+## Routing
+
+- First setup/auth check: `sendmux-getting-started`.
+- Independent outbound sending or batch sends: `sendmux-send-email`.
+- Domain/mailbox/key creation and mailbox admin: `sendmux-management`.
+- CLI command details: `sendmux-cli`.
+- Cheapest-call doctrine: `sendmux-token-efficient-usage`.
+
+## Limitations
+
+- Does not create mailboxes or mailbox keys; the source routes those tasks to sendmux-management.
+- Does not use root keys for mailbox work.
+- Requires explicit confirmation before message deletion, mutation, or mailbox sending.

--- a/skills/sendmux-management/SKILL.md
+++ b/skills/sendmux-management/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: sendmux-management
+description: "Manage Sendmux domains, mailboxes, keys, providers, webhooks, billing, logs, and metrics."
+risk: critical
+source: https://github.com/Sendmux/skills/tree/main/skills/sendmux-management
+---
+
+# Sendmux management
+
+Use this skill for team administration with an `smx_root_` key.
+
+## When to Use This Skill
+
+- Use when managing Sendmux account-level resources with an smx_root_ key.
+- Use for domains, mailbox provisioning, mailbox API keys, providers, webhooks, billing, spend, delivery logs, incoming logs, or metrics.
+- Use when choosing Management MCP, CLI, or SDK for account administration.
+
+## Copy-Paste Example
+
+```text
+User: "Create a Sendmux mailbox for agent@example.com and a mailbox key, but confirm before any destructive changes."
+```
+
+## Boundaries
+
+- Do not ask the user to paste an API key or one-time secret.
+- Use `smx_root_` keys for Management API calls.
+- Do not use management calls to read, triage, sync, or reply from a mailbox; route those tasks to `sendmux-mailbox-agent`.
+- Treat create-key and webhook-secret responses as sensitive one-time values. Put them only in the user's chosen secret store or secure output path.
+- Confirm destructive operations before deleting domains, mailboxes, mailbox keys, sending accounts, or webhooks.
+- Confirm the target resource before suspend, resume, rotate-secret, or test-delivery operations.
+
+## Surface choice
+
+| Task | Preferred surface |
+| --- | --- |
+| Domains | MCP for list/create/get/zone-file/verify; CLI or SDK for update/delete/filter rules. |
+| Mailboxes | MCP for list/create/get/update/suspend/resume/key create/key delete; CLI or SDK for delete and filters. |
+| Sending accounts | CLI or SDK. MCP does not curate provider tools yet. |
+| Webhooks | MCP for list/create/test; CLI or SDK for get/update/delete/rotate-secret/deliveries/payloads. |
+| Billing and spend | MCP `management_get_spend_summary`; CLI or SDK for balance and transactions. |
+| Outbound delivery logs and metrics | MCP for list/get logs and metrics; CLI or SDK also work. |
+| Incoming logs | CLI or SDK. MCP does not curate incoming-log tools yet. |
+
+For terminal work, use the `sendmux` CLI with `--json`. For application code, use `@sendmux/management` and `createManagementClient`.
+
+## Efficient defaults
+
+- Use small `limit` values on list endpoints and follow `pagination.next_cursor` only when more rows are needed.
+- Use `Idempotency-Key` on create, suspend, resume, rotate-secret, and test mutations that accept it.
+- Use `If-None-Match` for repeated detail reads that return `ETag`.
+- Use `If-Match` for update or replace operations when the API exposes optimistic concurrency.
+- For questions about counts or trends, use summary or metrics endpoints before log lists.
+- For one email or webhook delivery, list with filters first, then fetch the selected record.
+
+## Domains
+
+Use domains for sending setup and hosted mailbox domains.
+
+MCP tools:
+
+| Action | Tool |
+| --- | --- |
+| List | `management_list_domains` |
+| Create | `management_create_domain` |
+| Inspect | `management_get_domain` |
+| DNS records | `management_get_domain_zone_file` |
+| Verify DNS | `management_verify_domain` |
+
+CLI:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_ROOT_KEY" sendmux management:create-domain \
+  --idempotency-key "$IDEMPOTENCY_KEY" \
+  --body '{"domain":"example.com","mode":"send_receive"}' \
+  --json
+
+SENDMUX_API_KEY="$SENDMUX_ROOT_KEY" sendmux management:get-domain-zone-file \
+  --path public_id=mdom_abc \
+  --json
+
+SENDMUX_API_KEY="$SENDMUX_ROOT_KEY" sendmux management:verify-domain \
+  --path public_id=mdom_abc \
+  --json
+```
+
+SDK:
+
+```ts
+import {
+  createManagementClient,
+  managementCreateDomain,
+  managementGetDomainZoneFile,
+  managementVerifyDomain,
+} from "@sendmux/management";
+
+const client = createManagementClient({ apiKey: process.env.SENDMUX_API_KEY! });
+
+await managementCreateDomain({
+  client,
+  headers: { "Idempotency-Key": process.env.IDEMPOTENCY_KEY! },
+  body: { domain: "example.com", mode: "send_receive" },
+});
+
+const zone = await managementGetDomainZoneFile({
+  client,
+  path: { public_id: "mdom_abc" },
+});
+
+await managementVerifyDomain({
+  client,
+  path: { public_id: "mdom_abc" },
+});
+```
+
+Use CLI `management:update-domain` or SDK `managementUpdateDomain` with `If-Match` for mode upgrades. Confirm before delete.
+
+## Mailboxes and keys
+
+Create mailboxes with a root key; use mailbox keys afterwards for agent mailbox work.
+
+MCP tools:
+
+| Action | Tool |
+| --- | --- |
+| List | `management_list_mailboxes` |
+| Create | `management_create_mailbox` |
+| Inspect | `management_get_mailbox` |
+| Update | `management_update_mailbox` |
+| Suspend | `management_suspend_mailbox` |
+| Resume | `management_resume_mailbox` |
+| Create mailbox key | `management_create_mailbox_key` |
+| Delete mailbox key | `management_delete_mailbox_key` |
+
+CLI:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_ROOT_KEY" sendmux management:create-mailbox \
+  --idempotency-key "$IDEMPOTENCY_KEY" \
+  --body '{
+    "email": "agent@example.com",
+    "display_name": "Agent Inbox",
+    "quota_bytes": 1073741824
+  }' \
+  --json
+
+SENDMUX_API_KEY="$SENDMUX_ROOT_KEY" sendmux management:create-mailbox-key \
+  --path public_id=mbx_abc \
+  --idempotency-key "$IDEMPOTENCY_KEY" \
+  --body '{"name":"agent-runtime"}' \
+  --json
+```
+
+After creating a mailbox key, hand mailbox read/search/reply work to `sendmux-mailbox-agent` with the new `smx_mbx_` key.
+
+Suspend keeps the mailbox and messages but blocks mailbox access. Delete removes the mailbox and revokes associated keys; confirm deletion explicitly.
+
+## Sending accounts
+
+Sending-account management is full CLI/SDK territory until MCP curates provider tools.
+
+CLI commands:
+
+| Action | Command |
+| --- | --- |
+| List | `sendmux management:providers:list --json` |
+| Create | `sendmux management:create-provider --json` |
+| Inspect | `sendmux management:get-provider --json` |
+| Update | `sendmux management:update-provider --json` |
+| Activate | `sendmux management:activate-provider --json` |
+| Deactivate | `sendmux management:deactivate-provider --json` |
+| Test | `sendmux management:test-provider --json` |
+| Limits | `sendmux management:get-provider-limits --json` |
+| Stats | `sendmux management:get-provider-stats --json` |
+| Usage | `sendmux management:get-provider-usage --json` |
+
+SDK helpers include `managementListProviders`, `managementCreateProvider`, `managementGetProvider`, `managementUpdateProvider`, `managementActivateProvider`, `managementDeactivateProvider`, `managementTestProvider`, `managementGetProviderLimits`, `managementGetProviderStats`, and `managementGetProviderUsage`.
+
+Do not print provider credentials. Put secrets in the user's chosen secret store.
+
+## Webhooks
+
+MCP covers the common create-and-test path:
+
+| Action | Tool |
+| --- | --- |
+| List | `management_list_webhooks` |
+| Create | `management_create_webhook` |
+| Test | `management_test_webhook` |
+
+Use CLI or SDK for full lifecycle work:
+
+| Action | CLI command | SDK helper |
+| --- | --- | --- |
+| Inspect | `management:get-webhook` | `managementGetWebhook` |
+| Update | `management:update-webhook` | `managementUpdateWebhook` |
+| Delete | `management:delete-webhook` | `managementDeleteWebhook` |
+| Rotate secret | `management:rotate-webhook-secret` | `managementRotateWebhookSecret` |
+| List deliveries | `management:list-delivery` | `managementListDelivery` |
+| Get delivery payload | `management:get-delivery-payload` | `managementGetDeliveryPayload` |
+
+Use `Idempotency-Key` on create, rotate-secret, and test. Store the webhook signing secret at creation or rotation time; it cannot be retrieved later.
+
+## Billing, logs, and metrics
+
+Use read-only summary endpoints before broad log reads.
+
+| Question | Preferred call |
+| --- | --- |
+| Spend trend | `management_get_spend_summary`, CLI `management:get-spend-summary`, SDK `managementGetSpendSummary`. |
+| Current balance | CLI `management:list-balance`, SDK `managementListBalance`. |
+| Transaction history | CLI `management:list-transactions`, SDK `managementListTransactions`. |
+| Outbound delivery logs | `management_list_email_logs`, CLI `management:list-email-logs`, SDK `managementListEmailLogs`. |
+| One outbound log | `management_get_email_log`, CLI `management:get-email-log`, SDK `managementGetEmailLog`. |
+| Delivery metrics | `management_get_email_metrics`, CLI `management:get-email-metrics`, SDK `managementGetEmailMetrics`. |
+| Incoming logs | CLI `management:list-inbox-logs` / `management:get-inbox-log`, SDK `managementListInboxLogs` / `managementGetInboxLog`. |
+
+CLI:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_ROOT_KEY" sendmux management:get-spend-summary \
+  --query days=30 \
+  --json
+
+SENDMUX_API_KEY="$SENDMUX_ROOT_KEY" sendmux management:list-email-logs \
+  --query status=failed \
+  --query limit=20 \
+  --json
+
+SENDMUX_API_KEY="$SENDMUX_ROOT_KEY" sendmux management:get-email-log \
+  --path public_id=dlog_abc \
+  --header If-None-Match="$ETAG" \
+  --json
+```
+
+## Routing
+
+- First setup/auth check: `sendmux-getting-started`.
+- Single or batch transactional sending: `sendmux-send-email`.
+- Mailbox read, search, sync, triage, or reply: `sendmux-mailbox-agent`.
+- CLI command details: `sendmux-cli`.
+- MCP connection setup: `sendmux-mcp-setup`.
+- Cheapest-call doctrine: `sendmux-token-efficient-usage`.
+
+## Limitations
+
+- Does not read, triage, sync, or reply from a mailbox; the source routes that to sendmux-mailbox-agent.
+- Requires smx_root_ credentials for Management API calls.
+- Requires confirmation before destructive operations, suspend, resume, rotate-secret, or test-delivery operations.

--- a/skills/sendmux-mcp-setup/SKILL.md
+++ b/skills/sendmux-mcp-setup/SKILL.md
@@ -1,0 +1,405 @@
+---
+name: sendmux-mcp-setup
+description: "Configure hosted or local Sendmux MCP servers for mailbox, management, and sending tools."
+risk: safe
+source: https://github.com/Sendmux/skills/tree/main/skills/sendmux-mcp-setup
+---
+
+# Sendmux MCP setup
+
+Use this skill to connect an agent client to Sendmux through MCP.
+
+## When to Use This Skill
+
+- Use when connecting an agent client to Sendmux through hosted or local MCP.
+- Use when choosing hosted remote OAuth, local stdio, or local HTTP bearer setup.
+- Use when writing Sendmux MCP config for Claude Code, Cursor, Codex, VS Code, Copilot, Gemini CLI, Cline, or Windsurf.
+
+## Copy-Paste Example
+
+```text
+User: "Configure Sendmux MCP for Claude Code using hosted OAuth if supported; otherwise use local stdio with env vars."
+```
+
+## Boundaries
+
+- Do not ask the user to paste API keys or bearer tokens.
+- Use `smx_mbx_` keys or scoped `smx_agent_` tokens for Mailbox MCP tools.
+- Use send-capable `smx_mbx_` keys or owner-approved Sending-resource `smx_agent_` tokens for Sending MCP tools.
+- Use `smx_root_` keys for Management MCP tools.
+- Use hosted OAuth at `https://mcp.sendmux.ai/mcp` when the client supports remote MCP OAuth.
+- Use local stdio when the client cannot use hosted OAuth or local HTTP.
+- For local stdio or HTTP, pass Sendmux keys and owner-approved agent tokens through environment variables backed by the user's secret store; do not write raw tokens into checked-in MCP config.
+- Use local HTTP bearer only for local/private MCP servers; the bearer token protects the MCP endpoint and is separate from the Sendmux API key used upstream.
+- Use server-qualified names such as `sendmux-mailbox:mailbox_search_message_snippets` when a client needs fully-qualified tool names.
+
+## Install
+
+```bash
+pip install sendmux-mcp
+```
+
+Console scripts:
+
+- `sendmux-mcp` — combined local server; requires `--surfaces` or `SENDMUX_MCP_SURFACES`.
+- `sendmux-mcp-mailbox` — mailbox-only local server.
+- `sendmux-mcp-management` — management-only local server.
+- `sendmux-mcp-sending` — sending-only local server.
+- `sendmux-mcp-hosted` — hosted runtime; do not use this for normal local agent setup.
+
+## Choose A Setup
+
+| Setup             | Use when                                                       | Auth                                                                                  |
+| ----------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Hosted remote     | The client supports remote MCP OAuth.                          | Client signs in through Sendmux OAuth; do not pass API keys.                          |
+| Local stdio       | The agent runs a local child process.                          | Env vars passed to the server process.                                                |
+| Local HTTP bearer | A local/private MCP endpoint is shared by one or more clients. | Sendmux API key in server env; `Authorization: Bearer ...` from client to MCP server. |
+
+## Surface Map
+
+| Surface    | Key                                                                     | Tool count | Example tools                                                                                                                                         |
+| ---------- | ----------------------------------------------------------------------- | ---------: | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Mailbox    | `smx_mbx_` or scoped `smx_agent_`                                       |         21 | `mailbox_list_granted_mailboxes`, `mailbox_search_message_snippets`, `mailbox_batch_get_messages`, `mailbox_get_changes`, `mailbox_send_message`      |
+| Management | `smx_root_`                                                             |         20 | `management_create_domain`, `management_create_mailbox`, `management_create_mailbox_key`, `management_get_spend_summary`, `management_create_webhook` |
+| Sending    | Send-capable `smx_mbx_` or owner-approved Sending-resource `smx_agent_` |          2 | `sending_send_email`, `sending_send_email_batch`                                                                                                      |
+
+For multi-mailbox grants, call `mailbox_list_granted_mailboxes` first and pass the returned `mailbox_id` to mailbox tools when targeting a mailbox.
+
+## Local Servers
+
+Mailbox-only stdio:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux-mcp-mailbox
+```
+
+Management-only stdio:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_ROOT_KEY" sendmux-mcp-management
+```
+
+Sending-only stdio:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux-mcp-sending
+```
+
+Combined stdio:
+
+```bash
+SENDMUX_MCP_SURFACES=mailbox,management,sending \
+SENDMUX_MAILBOX_API_KEY="$SENDMUX_MBX_KEY" \
+SENDMUX_MANAGEMENT_API_KEY="$SENDMUX_ROOT_KEY" \
+SENDMUX_SENDING_API_KEY="$SENDMUX_MBX_KEY" \
+sendmux-mcp
+```
+
+Local HTTP bearer:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" \
+SENDMUX_MCP_HTTP_BEARER_TOKEN="$SENDMUX_MCP_HTTP_BEARER_TOKEN" \
+sendmux-mcp-mailbox --transport http --host 127.0.0.1 --port 8765 --path /mcp
+```
+
+Client header for that local HTTP server:
+
+```text
+Authorization: Bearer $SENDMUX_MCP_HTTP_BEARER_TOKEN
+```
+
+`/health` returns selected surfaces for local HTTP servers.
+
+## Common JSON Clients
+
+Use this shape for Cursor, Cline, and Windsurf/Cascade clients that read an `mcpServers` object.
+
+Local stdio, one mailbox server:
+
+```json
+{
+  "mcpServers": {
+    "sendmux-mailbox": {
+      "command": "sendmux-mcp-mailbox",
+      "env": {
+        "SENDMUX_API_KEY": "${env:SENDMUX_MBX_KEY}"
+      }
+    }
+  }
+}
+```
+
+Local stdio, all three surfaces:
+
+```json
+{
+  "mcpServers": {
+    "sendmux": {
+      "command": "sendmux-mcp",
+      "args": ["--surfaces", "mailbox,management,sending"],
+      "env": {
+        "SENDMUX_MAILBOX_API_KEY": "${env:SENDMUX_MBX_KEY}",
+        "SENDMUX_MANAGEMENT_API_KEY": "${env:SENDMUX_ROOT_KEY}",
+        "SENDMUX_SENDING_API_KEY": "${env:SENDMUX_MBX_KEY}"
+      }
+    }
+  }
+}
+```
+
+Local/private HTTP bearer:
+
+```json
+{
+  "mcpServers": {
+    "sendmux-local-http": {
+      "url": "http://127.0.0.1:8765/mcp",
+      "headers": {
+        "Authorization": "Bearer ${env:SENDMUX_MCP_HTTP_BEARER_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Hosted remote OAuth:
+
+```json
+{
+  "mcpServers": {
+    "sendmux": {
+      "url": "https://mcp.sendmux.ai/mcp"
+    }
+  }
+}
+```
+
+Client notes:
+
+- Cursor: put project config at `.cursor/mcp.json` or global config at `~/.cursor/mcp.json`; Cursor interpolates `${env:NAME}` in `command`, `args`, `env`, `url`, and `headers`.
+- Cline: use `~/.cline/mcp.json`, the Cline MCP UI, or `cline mcp`; remote setup can ask for URL and headers.
+- Windsurf/Cascade: use `~/.codeium/mcp_config.json` or **Settings** > **Tools** > **Windsurf Settings** > **Add Server**; HTTP config accepts `serverUrl` or `url`.
+
+## Claude Code
+
+Hosted remote OAuth:
+
+```bash
+claude mcp add --transport http sendmux https://mcp.sendmux.ai/mcp
+```
+
+Then run `/mcp` and complete the sign-in flow if prompted.
+
+Local stdio:
+
+```bash
+claude mcp add --transport stdio \
+  --env SENDMUX_API_KEY="$SENDMUX_MBX_KEY" \
+  sendmux-mailbox -- sendmux-mcp-mailbox
+```
+
+Local HTTP bearer:
+
+```bash
+claude mcp add --transport http \
+  sendmux-local-http http://127.0.0.1:8765/mcp \
+  --header "Authorization: Bearer $SENDMUX_MCP_HTTP_BEARER_TOKEN"
+```
+
+Project `.mcp.json` can also use `mcpServers` with `type`, `url` or `command`, `args`, `env`, and `headers`.
+
+## Codex
+
+Use `~/.codex/config.toml` for user-level config.
+
+Local stdio:
+
+```toml
+[mcp_servers.sendmux_mailbox]
+command = "sendmux-mcp-mailbox"
+env_vars = ["SENDMUX_API_KEY"]
+```
+
+Run Codex with `SENDMUX_API_KEY` set to an `smx_mbx_` key.
+
+Combined stdio:
+
+```toml
+[mcp_servers.sendmux]
+command = "sendmux-mcp"
+args = ["--surfaces", "mailbox,management,sending"]
+env_vars = ["SENDMUX_MAILBOX_API_KEY", "SENDMUX_MANAGEMENT_API_KEY", "SENDMUX_SENDING_API_KEY"]
+```
+
+Hosted remote OAuth:
+
+```toml
+[mcp_servers.sendmux]
+url = "https://mcp.sendmux.ai/mcp"
+oauth_resource = "https://mcp.sendmux.ai/mcp"
+```
+
+Local HTTP bearer:
+
+```toml
+[mcp_servers.sendmux_local_http]
+url = "http://127.0.0.1:8765/mcp"
+bearer_token_env_var = "SENDMUX_MCP_HTTP_BEARER_TOKEN"
+```
+
+## VS Code And GitHub Copilot
+
+VS Code stores MCP config in `.vscode/mcp.json` or user profile `mcp.json` under `servers`.
+
+Local stdio:
+
+```json
+{
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "sendmux-mbx-key",
+      "description": "Sendmux mailbox API key",
+      "password": true
+    }
+  ],
+  "servers": {
+    "sendmuxMailbox": {
+      "type": "stdio",
+      "command": "sendmux-mcp-mailbox",
+      "env": {
+        "SENDMUX_API_KEY": "${input:sendmux-mbx-key}"
+      }
+    }
+  }
+}
+```
+
+Local HTTP bearer:
+
+```json
+{
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "sendmux-mcp-token",
+      "description": "Sendmux local MCP bearer token",
+      "password": true
+    }
+  ],
+  "servers": {
+    "sendmuxLocalHttp": {
+      "type": "http",
+      "url": "http://127.0.0.1:8765/mcp",
+      "headers": {
+        "Authorization": "Bearer ${input:sendmux-mcp-token}"
+      }
+    }
+  }
+}
+```
+
+Hosted remote OAuth:
+
+```json
+{
+  "servers": {
+    "sendmux": {
+      "type": "http",
+      "url": "https://mcp.sendmux.ai/mcp"
+    }
+  }
+}
+```
+
+GitHub Copilot CLI can add servers interactively with `/mcp add` or non-interactively:
+
+```bash
+copilot mcp add sendmux-mailbox -- sendmux-mcp-mailbox
+copilot mcp add --transport http sendmux https://mcp.sendmux.ai/mcp
+copilot mcp add --transport http sendmux-local-http http://127.0.0.1:8765/mcp \
+  --header "Authorization: Bearer $SENDMUX_MCP_HTTP_BEARER_TOKEN"
+```
+
+## Gemini CLI
+
+Gemini CLI reads `mcpServers` from `settings.json`.
+
+Local stdio:
+
+```json
+{
+  "mcpServers": {
+    "sendmux-mailbox": {
+      "command": "sendmux-mcp-mailbox",
+      "env": {
+        "SENDMUX_API_KEY": "$SENDMUX_MBX_KEY"
+      },
+      "trust": false
+    }
+  }
+}
+```
+
+Hosted remote OAuth:
+
+```json
+{
+  "mcpServers": {
+    "sendmux": {
+      "httpUrl": "https://mcp.sendmux.ai/mcp",
+      "trust": false
+    }
+  }
+}
+```
+
+Local HTTP bearer:
+
+```json
+{
+  "mcpServers": {
+    "sendmux-local-http": {
+      "httpUrl": "http://127.0.0.1:8765/mcp",
+      "headers": {
+        "Authorization": "Bearer $SENDMUX_MCP_HTTP_BEARER_TOKEN"
+      },
+      "trust": false
+    }
+  }
+}
+```
+
+Use `/mcp auth sendmux` if the hosted remote endpoint needs OAuth authentication.
+
+## Verification
+
+After adding the server:
+
+1. Restart or refresh MCP servers in the client.
+2. Confirm the visible tools match the selected surfaces:
+   - Mailbox-only: no `management_*` or `sending_*` tools.
+   - Management-only: no `mailbox_*` or `sending_*` tools.
+   - Sending-only: only `sending_send_email` and `sending_send_email_batch`.
+3. Run one harmless read tool:
+   - Mailbox: `mailbox_get_me` or `mailbox_get_session`.
+   - Management: `management_list_domains` with a small limit.
+   - Sending: list tools only unless the user confirms a real send.
+4. If local HTTP returns `401`, check the client `Authorization` header against `SENDMUX_MCP_HTTP_BEARER_TOKEN`.
+5. If the process exits before connecting, check the Sendmux key prefix for the selected surface.
+
+## Routing
+
+- First Sendmux API setup or first call: `sendmux-getting-started`.
+- Sending body shape or send strategy: `sendmux-send-email`.
+- Mailbox read, search, sync, triage, or reply: `sendmux-mailbox-agent`.
+- Account-level management strategy: `sendmux-management`.
+- Terminal command mechanics: `sendmux-cli`.
+- Cheapest-call doctrine: `sendmux-token-efficient-usage`.
+
+## Limitations
+
+- Does not ask for or write raw API keys into checked-in MCP config.
+- Does not send email; the source says list Sending tools only unless the user confirms a real send.
+- Requires client-specific MCP support for hosted OAuth, stdio, or HTTP bearer transport.

--- a/skills/sendmux-send-email/SKILL.md
+++ b/skills/sendmux-send-email/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: sendmux-send-email
+description: "Send outbound email through Sendmux with confirmation, idempotency, batch, CLI, SDK, and HTTP patterns."
+risk: critical
+source: https://github.com/Sendmux/skills/tree/main/skills/sendmux-send-email
+---
+
+# Sendmux send email
+
+Use this skill when the user is ready to send outbound email through Sendmux or needs code/commands for sending.
+
+## When to Use This Skill
+
+- Use when the user is ready to send one or more outbound emails through Sendmux.
+- Use when choosing single versus batch Sending API calls.
+- Use when adding idempotency keys, attachments, or Sendmux CLI/SDK/HTTP send examples.
+
+## Copy-Paste Example
+
+```text
+User: "Send one Sendmux email from sender@example.com to recipient@example.com with this subject and body, using an idempotency key."
+```
+
+## Safety first
+
+- Do not ask the user to paste an API key.
+- Do not invent recipients, sender addresses, subject lines, or body content.
+- Send only after the user supplies or confirms every recipient and message.
+- For batch sends, confirm the full recipient/message set before calling a send tool.
+- Use a send-capable `smx_mbx_` key or owner-approved Sending-resource `smx_agent_` token for the Sending API.
+- Do not use a pre-claim `smx_agent_` token for sending. Pre-claim self-registered agent tokens have `mailbox.read` and `email.receive`, not `email.send`.
+- If using a self-registered agent, obtain the Sending-resource `smx_agent_` token by exchanging the saved `claim_token` after owner approval with `resource=https://smtp.sendmux.ai/api/v1`.
+
+## Choose the send path
+
+| User task                                 | Efficient default                                                                                                                      |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| One outbound email                        | `POST /emails/send`, MCP `sending_send_email`, CLI `sending:send`, or SDK `sendingSendEmail`.                                          |
+| More than one independent outbound email  | Batch by default: `POST /emails/send/batch`, MCP `sending_send_email_batch`, CLI `sending:send:batch`, or SDK `sendingSendEmailBatch`. |
+| Replying while working inside one mailbox | Use mailbox send from `sendmux-mailbox-agent` when the workflow is mailbox-centred.                                                    |
+| Existing app only supports SMTP           | Use SMTP only because the existing tool requires it. For new agent or app integrations, prefer the HTTP Sending API.                   |
+
+Batch sends accept up to 100 messages. A batch response can partially succeed, so inspect every result item.
+
+## Required JSON shape
+
+Single send body:
+
+```json
+{
+  "from": { "email": "sender@example.com", "name": "Sender Name" },
+  "to": { "email": "recipient@example.com", "name": "Recipient Name" },
+  "subject": "Subject line",
+  "html_body": "<p>Hello.</p>",
+  "text_body": "Hello."
+}
+```
+
+Required fields: `from`, `to`, `subject`, `html_body`.
+
+Useful optional fields:
+
+- `text_body`: plain text alternative.
+- `cc`, `bcc`: arrays of recipients, max 100 each.
+- `reply_to`: one address object.
+- `return_path`: envelope sender for bounce handling.
+- `custom_headers`: custom `X-*` headers.
+- `attachments`: up to 10 items, each with `filename` and base64 `content`; optional `type`; `encoding` is `base64`.
+
+Batch send body:
+
+```json
+{
+  "messages": [
+    {
+      "from": { "email": "sender@example.com" },
+      "to": { "email": "alice@example.com" },
+      "subject": "Hello Alice",
+      "html_body": "<p>Hi Alice.</p>"
+    },
+    {
+      "from": { "email": "sender@example.com" },
+      "to": { "email": "bob@example.com" },
+      "subject": "Hello Bob",
+      "html_body": "<p>Hi Bob.</p>"
+    }
+  ]
+}
+```
+
+## Idempotency
+
+Add `Idempotency-Key` to every send that may be retried. Use one stable key per logical email or batch.
+
+- Same key and same body: returns the cached response for 24 hours.
+- Same key and different body: returns `409 idempotency_conflict`.
+- Keep keys under 255 characters.
+
+## MCP
+
+Use MCP when the user's agent already has the Sending server connected:
+
+- One message: `sending_send_email`.
+- Multiple messages: `sending_send_email_batch`.
+
+Include an idempotency key when the client exposes the header parameter. If the MCP client does not expose headers clearly, use CLI, SDK, or direct HTTP for retry-sensitive sends.
+
+## CLI
+
+One email:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux sending:send \
+  --idempotency-key "$IDEMPOTENCY_KEY" \
+  --body '{
+    "from": { "email": "sender@example.com", "name": "Sender Name" },
+    "to": { "email": "recipient@example.com", "name": "Recipient Name" },
+    "subject": "Subject line",
+    "html_body": "<p>Hello.</p>",
+    "text_body": "Hello."
+  }' \
+  --json
+```
+
+Batch:
+
+```bash
+SENDMUX_API_KEY="$SENDMUX_MBX_KEY" sendmux sending:send:batch \
+  --idempotency-key "$IDEMPOTENCY_KEY" \
+  --body-file ./sendmux-batch.json \
+  --json
+```
+
+Use `--body-file` for attachments or larger JSON payloads to avoid shell escaping mistakes.
+
+## TypeScript SDK
+
+One email:
+
+```ts
+import { createSendingClient, sendingSendEmail } from "@sendmux/sending";
+
+const client = createSendingClient({ apiKey: process.env.SENDMUX_API_KEY! });
+
+const response = await sendingSendEmail({
+  client,
+  headers: { "Idempotency-Key": idempotencyKey },
+  body: {
+    from: { email: "sender@example.com", name: "Sender Name" },
+    to: { email: "recipient@example.com", name: "Recipient Name" },
+    subject: "Subject line",
+    html_body: "<p>Hello.</p>",
+    text_body: "Hello.",
+  },
+});
+
+console.log(response.data.message_id, response.data.status);
+```
+
+Batch:
+
+```ts
+import { createSendingClient, sendingSendEmailBatch } from "@sendmux/sending";
+
+const client = createSendingClient({ apiKey: process.env.SENDMUX_API_KEY! });
+
+const response = await sendingSendEmailBatch({
+  client,
+  headers: { "Idempotency-Key": idempotencyKey },
+  body: {
+    messages,
+  },
+});
+
+for (const result of response.data.results) {
+  console.log(result.index, result.status, result.message_id, result.error);
+}
+```
+
+## Direct HTTP
+
+Use direct HTTP only when MCP, CLI, or SDK is unavailable:
+
+```bash
+curl -X POST https://smtp.sendmux.ai/api/v1/emails/send \
+  -H "Authorization: Bearer $SENDMUX_MBX_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: $IDEMPOTENCY_KEY" \
+  -d @sendmux-email.json
+```
+
+## Responses and errors
+
+Single send success returns a `200` success envelope with:
+
+- `data.message_id`: `eml_...`
+- `data.status`: `queued`
+
+Batch success returns a `200` success envelope with:
+
+- `data.summary.total`
+- `data.summary.queued`
+- `data.summary.failed`
+- `data.results[]` containing `index`, `status`, `message_id`, and optional `error`
+
+Handle these errors deliberately:
+
+- `401`: missing, invalid, or revoked key.
+- `402`: insufficient credits.
+- `403`: key lacks `email.send`, is not allowed for the sender, or uses the wrong surface.
+- `409`: idempotency conflict.
+- `413`: request body exceeds 25 MB.
+- `422`: validation failed; read `error.errors`.
+- `429` or `503`: retry according to response headers.
+
+## Routing
+
+- Setup/auth first call: `sendmux-getting-started`.
+- Mailbox-centred replies: `sendmux-mailbox-agent`.
+- CLI-only details: `sendmux-cli`.
+- Cheapest-call decisions: `sendmux-token-efficient-usage`.
+
+## Limitations
+
+- Does not invent recipients, sender addresses, subject lines, or body content.
+- Does not send with pre-claim smx_agent_ tokens; the source says they lack email.send.
+- Requires user confirmation before any send, especially batch sends.

--- a/skills/sendmux-token-efficient-usage/SKILL.md
+++ b/skills/sendmux-token-efficient-usage/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: sendmux-token-efficient-usage
+description: "Choose low-token Sendmux routes with batching, snippets, sync deltas, pagination, ETags, and idempotency."
+risk: critical
+source: https://github.com/Sendmux/skills/tree/main/skills/sendmux-token-efficient-usage
+---
+
+# Sendmux token-efficient usage
+
+Use this skill to choose the lowest-cost Sendmux route that still answers the task correctly.
+
+## When to Use This Skill
+
+- Use when a Sendmux task could use MCP, CLI, SDK, or direct HTTP and the user needs the cheapest correct route.
+- Use when choosing batch sends, mailbox search/count/batch reads, sync deltas, cursor pagination, ETags, or idempotency keys.
+- Use when avoiding broad mailbox body reads, full mailbox scans, or broad log fetches.
+
+## Copy-Paste Example
+
+```text
+User: "Find unread invoice mail with as few Sendmux calls as possible; count, search snippets, then batch-get selected IDs."
+```
+
+## Boundaries
+
+- Do not ask the user to paste an API key.
+- Use send-capable `smx_mbx_*` keys or owner-approved Sending-resource `smx_agent_*` tokens for Sending calls, and `smx_mbx_*` keys for normal Mailbox calls.
+- Use scoped `smx_agent_*` only for the calls its scopes and resource allow. Pre-claim agent tokens cannot send.
+- Use `smx_root_*` for Management calls.
+- Do not default to MCP for every task. MCP is best when the required tool is curated; CLI and SDK cover broader surfaces.
+- Do not read full mailbox bodies, every message, or every log row unless the user asks for full content and narrower calls cannot answer.
+
+## Surface choice
+
+| Situation                               | Use                                 | Why                                                           |
+| --------------------------------------- | ----------------------------------- | ------------------------------------------------------------- |
+| Connected agent and curated tool exists | MCP tool                            | Small schema and no SDK boilerplate.                          |
+| One-off terminal task                   | `sendmux` CLI with `--json`         | Direct, scriptable, exposes the full generated operation set. |
+| Application code or repeated workflow   | SDK for the project already in use  | Reuses client setup, pagination, headers, and retry helpers.  |
+| MCP lacks the needed operation          | CLI for terminal work, SDK for code | Do not invent uncurated MCP tools.                            |
+| No package/tooling available            | Direct HTTP                         | Keep request bodies and headers aligned to OpenAPI.           |
+
+## Cheapest-call map
+
+| Task                            | Cheapest correct default                                                                                                               |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Send one outbound email         | `sending_send_email`, CLI `sending:send`, SDK `sendingSendEmail`; include `Idempotency-Key`.                                           |
+| Send multiple outbound emails   | `sending_send_email_batch`, CLI `sending:send:batch`, SDK `sendingSendEmailBatch`; do not loop single sends.                           |
+| Count matching mailbox messages | `mailbox_count_messages`, CLI `mailbox:count-messages`, SDK `mailboxCountMessages`.                                                    |
+| Search mailbox text             | `mailbox_search_message_snippets`, CLI `mailbox:search-message-snippets`, SDK `mailboxSearchMessageSnippets`; then fetch selected IDs. |
+| Read several known messages     | `mailbox_batch_get_messages`, CLI `mailbox:batch-get-messages`, SDK `mailboxBatchGetMessages`.                                         |
+| Update/delete several messages  | Batch update/delete after explicit confirmation.                                                                                       |
+| Resume broad mailbox sync       | `mailbox_get_changes`, CLI `mailbox:get-changes`, SDK `mailboxGetChanges`.                                                             |
+| Resume filtered mailbox sync    | CLI/SDK `mailbox:query-message-changes` / `mailboxQueryMessageChanges`; MCP does not curate it yet.                                    |
+| Watch live mailbox events       | CLI/SDK `mailbox:stream-events` / `mailboxStreamEvents`; MCP does not curate it yet.                                                   |
+| Scan threads                    | List threads, then fetch one thread or its messages.                                                                                   |
+| Manage domains/mailboxes/keys   | Management MCP for curated create/list/get/update/suspend/resume/key tools; CLI/SDK for uncovered lifecycle work.                      |
+| Manage sending accounts         | CLI/SDK; MCP does not curate provider tools yet.                                                                                       |
+| Manage webhooks                 | MCP for list/create/test; CLI/SDK for get/update/delete/rotate/delivery payloads.                                                      |
+| Inspect spend, logs, metrics    | Summary/metrics first; filter log lists with small `limit`, then fetch one selected row.                                               |
+
+## Read less
+
+For mailbox questions, reduce the result set before reading content:
+
+1. Count when the user asks "how many" or when the query may be broad.
+2. Search snippets with a small `limit` when the user needs examples.
+3. Batch-get only selected message IDs.
+4. Request clean body/content only when message text affects the answer.
+
+CLI:
+
+```bash
+sendmux mailbox:count-messages \
+  --query q=invoice \
+  --query is_unread=true \
+  --json
+
+sendmux mailbox:search-message-snippets \
+  --query q=invoice \
+  --query is_unread=true \
+  --query limit=10 \
+  --json
+
+sendmux mailbox:batch-get-messages \
+  --body '{
+    "ids": ["eml_abc", "eml_def"],
+    "body_mode": "clean_json",
+    "max_body_chars": 4000,
+    "strip_quotes": true,
+    "strip_signature": true,
+    "include_attachments": "metadata"
+  }' \
+  --json
+```
+
+## Write fewer requests
+
+Batch when there is more than one target.
+
+```bash
+sendmux sending:send:batch \
+  --idempotency-key "$IDEMPOTENCY_KEY" \
+  --body-file ./messages.json \
+  --json
+
+sendmux mailbox:batch-update-messages \
+  --body '{
+    "ids": ["eml_abc", "eml_def"],
+    "seen": true,
+    "if_in_state": "state_from_prior_read"
+  }' \
+  --json
+```
+
+For batch sends, inspect every per-message result before reporting success. Batch can contain mixed outcomes.
+
+## Sync by delta
+
+Use sync endpoints instead of re-listing stable data.
+
+Broad mailbox sync:
+
+```bash
+sendmux mailbox:get-changes \
+  --query messages_since_state="$MESSAGES_STATE" \
+  --query folders_since_state="$FOLDERS_STATE" \
+  --query threads_since_state="$THREADS_STATE" \
+  --query limit=100 \
+  --json
+```
+
+Filtered message sync:
+
+```bash
+sendmux mailbox:query-message-changes \
+  --query since_query_state="$QUERY_STATE" \
+  --query q=invoice \
+  --query is_unread=true \
+  --query limit=100 \
+  --json
+```
+
+Store the returned state token. Continue with the same filters only while `has_more` is true and the next page is needed.
+
+## Transfer less
+
+- Use small `limit` values on list calls.
+- Follow `pagination.next_cursor` only until enough evidence has been gathered.
+- Prefer summary or metrics endpoints before log lists.
+- Use `If-None-Match` for repeated detail reads that previously returned an `ETag`.
+- Use `If-Match` for updates when the prior read returned an `ETag`.
+
+CLI conditional examples:
+
+```bash
+sendmux management:get-email-log \
+  --path public_id=dlog_abc \
+  --if-none-match "$ETAG" \
+  --json
+
+sendmux management:update-mailbox \
+  --path public_id=mbx_abc \
+  --if-match "$ETAG" \
+  --body '{"display_name":"Agent Inbox"}' \
+  --json
+```
+
+SDK helpers:
+
+```
+import {
+  conditionalHeaders,
+  idempotencyHeaders,
+  paginate,
+  responseEtag,
+} from "@sendmux/core";
+
+const headers = conditionalHeaders({ ifNoneMatch: priorEtag });
+const writeHeaders = {
+  ...conditionalHeaders({ etag: priorEtag }),
+  ...idempotencyHeaders(operationKey),
+};
+```
+
+## Retry safely
+
+Use `Idempotency-Key` on supported mutations so retrying does not create duplicate work.
+
+Good candidates:
+
+- `sending:send` and `sending:send:batch`.
+- `mailbox:send-message`.
+- Management creates, mailbox key creation, suspend/resume, provider mutations, webhook create/rotate/test.
+
+When retrying application code, prefer SDK retry helpers only for safe reads or idempotent writes. Non-idempotent writes should fail rather than risk duplicate side effects.
+
+## Routing
+
+- Setup, key scopes, first call: `sendmux-getting-started`.
+- Email send bodies, attachments, SMTP-vs-HTTP choice: `sendmux-send-email`.
+- Mailbox read/search/sync/triage/reply details: `sendmux-mailbox-agent`.
+- Management domains, mailboxes, webhooks, billing, logs: `sendmux-management`.
+- CLI syntax and profiles: `sendmux-cli`.
+- MCP installation and client config: `sendmux-mcp-setup`.
+
+## Limitations
+
+- Does not invent uncurated MCP tools when CLI or SDK is the broader supported surface.
+- Does not read full mailbox bodies, every message, or every log row unless narrower calls cannot answer the task.
+- Some recommended routes can send or mutate state, so user confirmation and idempotency still matter.

--- a/skills_index.json
+++ b/skills_index.json
@@ -5679,6 +5679,78 @@
     "source": "vibeship-spawner-skills (Apache 2.0)"
   },
   {
+    "id": "sendmux-cli",
+    "path": "skills/sendmux-cli",
+    "category": "uncategorized",
+    "name": "sendmux-cli",
+    "description": "Use the Sendmux CLI for profiles, key-scope checks, JSON output, and generated operation commands.",
+    "risk": "critical",
+    "source": "https://github.com/Sendmux/skills/tree/main/skills/sendmux-cli"
+  },
+  {
+    "id": "sendmux-email-for-agents",
+    "path": "skills/sendmux-email-for-agents",
+    "category": "uncategorized",
+    "name": "sendmux-email-for-agents",
+    "description": "Route agent email workflows across Sendmux setup, self-registration, mailbox runtime, sending, and approval.",
+    "risk": "critical",
+    "source": "https://github.com/Sendmux/skills/tree/main/skills/sendmux-email-for-agents"
+  },
+  {
+    "id": "sendmux-getting-started",
+    "path": "skills/sendmux-getting-started",
+    "category": "uncategorized",
+    "name": "sendmux-getting-started",
+    "description": "Set up Sendmux, choose key scopes, verify first harmless calls, and route agent registration.",
+    "risk": "critical",
+    "source": "https://github.com/Sendmux/skills/tree/main/skills/sendmux-getting-started"
+  },
+  {
+    "id": "sendmux-mailbox-agent",
+    "path": "skills/sendmux-mailbox-agent",
+    "category": "uncategorized",
+    "name": "sendmux-mailbox-agent",
+    "description": "Read, search, sync, triage, mutate, or reply from one Sendmux mailbox efficiently.",
+    "risk": "critical",
+    "source": "https://github.com/Sendmux/skills/tree/main/skills/sendmux-mailbox-agent"
+  },
+  {
+    "id": "sendmux-management",
+    "path": "skills/sendmux-management",
+    "category": "uncategorized",
+    "name": "sendmux-management",
+    "description": "Manage Sendmux domains, mailboxes, keys, providers, webhooks, billing, logs, and metrics.",
+    "risk": "critical",
+    "source": "https://github.com/Sendmux/skills/tree/main/skills/sendmux-management"
+  },
+  {
+    "id": "sendmux-mcp-setup",
+    "path": "skills/sendmux-mcp-setup",
+    "category": "uncategorized",
+    "name": "sendmux-mcp-setup",
+    "description": "Configure hosted or local Sendmux MCP servers for mailbox, management, and sending tools.",
+    "risk": "safe",
+    "source": "https://github.com/Sendmux/skills/tree/main/skills/sendmux-mcp-setup"
+  },
+  {
+    "id": "sendmux-send-email",
+    "path": "skills/sendmux-send-email",
+    "category": "uncategorized",
+    "name": "sendmux-send-email",
+    "description": "Send outbound email through Sendmux with confirmation, idempotency, batch, CLI, SDK, and HTTP patterns.",
+    "risk": "critical",
+    "source": "https://github.com/Sendmux/skills/tree/main/skills/sendmux-send-email"
+  },
+  {
+    "id": "sendmux-token-efficient-usage",
+    "path": "skills/sendmux-token-efficient-usage",
+    "category": "uncategorized",
+    "name": "sendmux-token-efficient-usage",
+    "description": "Choose low-token Sendmux routes with batching, snippets, sync deltas, pagination, ETags, and idempotency.",
+    "risk": "critical",
+    "source": "https://github.com/Sendmux/skills/tree/main/skills/sendmux-token-efficient-usage"
+  },
+  {
     "id": "senior-architect",
     "path": "skills/senior-architect",
     "category": "uncategorized",


### PR DESCRIPTION
Adds the Sendmux skills from Sendmux/skills.

I kept the original skill text and added the bits this repo expects: risk/source frontmatter, when-to-use sections, a copy-paste example, and limitations.

Validation notes:
- npm ci: ok; npm reported one moderate audit finding
- pip install -r requirements.txt: could not run because this repo has no root requirements.txt
- npm run validate: ok
- npm run validate:strict: fails on existing non-Sendmux skills; no sendmux-* files are in that failure log
- npm run chain: ok, updated skills_index.json