### PR TITLE
feat: add WebGL and SDF liquid glass skills

### DIFF
--- a/skills/build-sdf-liquid-glass/SKILL.md
+++ b/skills/build-sdf-liquid-glass/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: build-sdf-liquid-glass
+description: Build lightweight SDF/canvas displacement glass with Vaso. Use for responsive refractive cards, no-WebGL fallbacks, many compact surfaces, or explicit SDF requests.
+risk: safe
+source: https://github.com/woodfishhhh/glass-material-skills
+---
+
+# Build SDF Liquid Glass
+
+Create a bounded displacement lens with a sharp, accessible content layer.
+
+## When to Use This Skill
+
+- Use when the user explicitly asks for SDF glass, Canvas Map, Vaso, or the WeFlow D material.
+- Use when WebGL is unavailable or many compact glass cards make a shared GPU renderer inappropriate.
+- Do not select it by default when the WebGL liquid-glass approach is suitable.
+
+## Example Request
+
+```text
+Use build-sdf-liquid-glass to add a responsive Vaso notification card with sharp DOM text above the displacement layer.
+```
+
+## Workflow
+
+1. Inspect the existing component framework, card dimensions, background, and browser targets.
+2. Install `vaso` with the repository's package manager.
+3. Adapt `assets/react/SDFLiquidGlass.tsx` and `sdf-liquid-glass.css` for React projects. Preserve the same layer separation elsewhere.
+4. Render Vaso as an absolute background layer and place text and controls in a sibling overlay. Do not let the displacement filter process readable content.
+5. Measure the host with `ResizeObserver` instead of hard-coding responsive width.
+6. Keep a translucent CSS background under the effect so unsupported browsers still show a usable card.
+7. Verify light, dark, and detailed backgrounds. Drag or resize the surface and check that the map follows its bounds.
+
+## Default Tuning
+
+Start with:
+
+- `radius: 16`
+- `depth: 0.58`
+- `blur: 0.4`
+- `dispersion: 0.32`
+- Stable notification height: `86px`
+
+Read `references/tuning.md` before increasing depth or dispersion.
+
+## Quality Gates
+
+- Keep foreground content crisp and outside the filtered layer.
+- Reject doubled text, rainbow fringes across glyphs, stale canvas dimensions, and clipped rounded corners.
+- Keep `depth` subtle for operational UI; use stronger distortion only for decorative surfaces.
+- Test resize behavior, Chromium desktop, and a mobile viewport.
+- Check the console and preserve readable CSS fallback colors.
+
+## Default Preference
+
+If the user asks only for an optimized glass material without naming D/SDF/Vaso, use `$build-webgl-liquid-glass` instead.
+
+## Limitations
+
+- Requires browser support for SVG filters and `backdrop-filter` for the full effect.
+- Strong depth or dispersion values can create distracting edge artifacts.
+- The effect must be remeasured after responsive size changes.
+- Browser rendering cannot reproduce a native desktop compositor exactly.

--- a/skills/build-sdf-liquid-glass/assets/react/SDFLiquidGlass.tsx
+++ b/skills/build-sdf-liquid-glass/assets/react/SDFLiquidGlass.tsx
@@ -1,0 +1,59 @@
+import { useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react'
+import { Vaso } from 'vaso'
+
+export interface SDFLiquidGlassProps {
+  children: ReactNode
+  className?: string
+  height?: number
+  radius?: number
+  depth?: number
+  blur?: number
+  dispersion?: number
+  style?: CSSProperties
+}
+
+export function SDFLiquidGlass({
+  children,
+  className = '',
+  height = 86,
+  radius = 16,
+  depth = 0.58,
+  blur = 0.4,
+  dispersion = 0.32,
+  style
+}: SDFLiquidGlassProps) {
+  const hostRef = useRef<HTMLDivElement>(null)
+  const [width, setWidth] = useState(1)
+
+  useLayoutEffect(() => {
+    const host = hostRef.current
+    if (!host) return
+
+    const update = () => setWidth(Math.max(1, Math.round(host.getBoundingClientRect().width)))
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(host)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div
+      ref={hostRef}
+      className={`sdf-liquid-glass ${className}`.trim()}
+      style={{ ...style, minHeight: height, borderRadius: radius }}
+    >
+      <Vaso
+        className="sdf-liquid-glass__effect"
+        width={width}
+        height={height}
+        radius={radius}
+        depth={depth}
+        blur={blur}
+        dispersion={dispersion}
+      >
+        <div style={{ width, height }} />
+      </Vaso>
+      <div className="sdf-liquid-glass__content">{children}</div>
+    </div>
+  )
+}

--- a/skills/build-sdf-liquid-glass/assets/react/sdf-liquid-glass.css
+++ b/skills/build-sdf-liquid-glass/assets/react/sdf-liquid-glass.css
@@ -1,0 +1,30 @@
+.sdf-liquid-glass {
+  --glass-tint: rgba(255, 255, 255, 0.14);
+  --glass-border: rgba(255, 255, 255, 0.28);
+  --glass-shadow: 0 6px 18px rgba(0, 0, 0, 0.24);
+
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  background: var(--glass-tint);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.34), var(--glass-shadow);
+  backdrop-filter: blur(8px) saturate(140%);
+}
+
+.sdf-liquid-glass__effect {
+  position: absolute !important;
+  inset: 0;
+}
+
+.sdf-liquid-glass [data-vaso] {
+  background: var(--glass-tint);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.36) !important;
+}
+
+.sdf-liquid-glass__content {
+  position: relative;
+  z-index: 2;
+  min-height: inherit;
+  padding: 14px 16px;
+}

--- a/skills/build-sdf-liquid-glass/references/tuning.md
+++ b/skills/build-sdf-liquid-glass/references/tuning.md
@@ -1,0 +1,27 @@
+# SDF Tuning
+
+Source: [huozhi/vaso](https://github.com/huozhi/vaso), MIT license. Vaso is based on Shuding's liquid-glass experiment.
+
+## Parameter Guide
+
+| Parameter | Start | Change carefully |
+| --- | ---: | --- |
+| `depth` | `0.58` | Use `0.35-0.8` for readable UI. Values near `2` are decorative. |
+| `blur` | `0.4` | Increase for privacy, but keep text outside the filtered layer. |
+| `dispersion` | `0.32` | Reduce first when colored edge fringes become distracting. |
+| `radius` | `16` | Match the host radius exactly to avoid exposed corners. |
+
+## Integration Rules
+
+- Keep Vaso in an absolute background layer.
+- Render text, icons, buttons, and focus rings in an unfiltered sibling overlay.
+- Measure responsive width with `ResizeObserver`; pass explicit width and height to Vaso.
+- Keep a CSS tint and backdrop blur under the effect as a browser fallback.
+- Avoid remounting the effect on every pointer move; update position with the host element.
+
+## Failure Signatures
+
+- **Text looks doubled or rainbow-split:** Foreground content is inside the filtered layer.
+- **Map is cropped or stretched:** Vaso dimensions do not match the host after resize.
+- **Corners leak:** Radius differs between host, effect, and `[data-vaso]` layer.
+- **Card is too milky:** Reduce CSS tint or Vaso blur before increasing depth.

--- a/skills/build-webgl-liquid-glass/SKILL.md
+++ b/skills/build-webgl-liquid-glass/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: build-webgl-liquid-glass
+description: Build production-ready GPU liquid-glass surfaces with liquid-gl for React or DOM UIs. Default for refractive cards, notifications, panels, GPU bevels, and WebGL glass.
+risk: safe
+source: https://github.com/woodfishhhh/glass-material-skills
+---
+
+# Build WebGL Liquid Glass
+
+Create a real refractive material while keeping text and controls crisp above the lens.
+
+## When to Use This Skill
+
+- Use when the user asks for optimized liquid glass, GPU refraction, floating glass panels, or refractive notification cards.
+- Use as the default glass implementation when WebGL is available and the interface has a small number of important surfaces.
+- Do not use when the user explicitly requests SDF/Vaso or needs hundreds of simultaneous glass items.
+
+## Example Request
+
+```text
+Use build-webgl-liquid-glass to add a draggable refractive notification card over this page's real background while keeping its text crisp.
+```
+
+## Workflow
+
+1. Inspect the existing framework, styling conventions, target background, and browser support.
+2. Install `liquid-gl` with the repository's package manager.
+3. Adapt `assets/react/WebGLLiquidGlass.tsx`, `webgl-liquid-glass.css`, and `liquid-gl.d.ts` for React projects. Preserve the same DOM layering in other frameworks.
+4. Keep the WebGL target empty. Put readable content in a sibling overlay; never place text inside the rasterized lens target.
+5. Point `snapshotSelector` at the real visual background, not the glass card or the whole app when avoidable.
+6. Initialize after the target and background assets exist. Register animated or replaceable backgrounds with `liquidGL.registerDynamic()`.
+7. Preserve a CSS `backdrop-filter` fallback and legible foreground colors when WebGL is unavailable.
+8. Verify the result over light, dark, and high-frequency backgrounds. Drag or scroll the surface and confirm refraction stays aligned.
+
+## Default Tuning
+
+Start with the asset defaults:
+
+- `resolution: 1.5`
+- `refraction: 0.007`
+- `aberration: 0.03`
+- `bevelDepth: 0.075`
+- `bevelWidth: 0.18`
+- `frost: 2.2`
+- `magnify: 1.006`
+- `shadow: false`, `specular: true`, `tilt: false`
+
+Read `references/tuning.md` before changing these values or adding several lenses.
+
+## Quality Gates
+
+- Keep content as DOM text above the lens. Reject duplicated, blurred, or chromatically split text.
+- Avoid hard clipping, detached refraction, stale snapshots, black canvases, and visible shader seams.
+- Keep the surface dimensions stable during loading and interaction.
+- Reduce resolution and disable expensive options before replacing the WebGL approach.
+- Respect `prefers-reduced-motion`; do not add tilt or elastic motion by default.
+- Test Chromium desktop and a mobile viewport. Check the console and confirm the fallback remains usable.
+
+## Fallback Choice
+
+Use `$build-sdf-liquid-glass` only when the user explicitly selects D/SDF, WebGL is unavailable, or many simultaneous glass surfaces make the shared GPU renderer inappropriate.
+
+## Limitations
+
+- Requires browser WebGL and a capturable visual background.
+- A large number of lenses can consume significant GPU resources.
+- Dynamic backgrounds require explicit registration to keep snapshots current.
+- Browser rendering cannot reproduce a native desktop compositor exactly.

--- a/skills/build-webgl-liquid-glass/assets/react/WebGLLiquidGlass.tsx
+++ b/skills/build-webgl-liquid-glass/assets/react/WebGLLiquidGlass.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useId, type CSSProperties, type ReactNode } from 'react'
+import liquidGL from 'liquid-gl'
+
+const initializedTargets = new Set<string>()
+
+export interface WebGLLiquidGlassProps {
+  children: ReactNode
+  className?: string
+  snapshotSelector?: string
+  dynamicSelector?: string
+  style?: CSSProperties
+}
+
+export function WebGLLiquidGlass({
+  children,
+  className = '',
+  snapshotSelector = 'body',
+  dynamicSelector,
+  style
+}: WebGLLiquidGlassProps) {
+  const targetId = `liquid-gl-${useId().replace(/:/g, '')}`
+
+  useEffect(() => {
+    if (initializedTargets.has(targetId)) return
+
+    const timer = window.setTimeout(() => {
+      liquidGL({
+        target: `#${targetId}`,
+        snapshot: snapshotSelector,
+        resolution: 1.5,
+        refraction: 0.007,
+        aberration: 0.03,
+        bevelDepth: 0.075,
+        bevelWidth: 0.18,
+        frost: 2.2,
+        shadow: false,
+        specular: true,
+        reveal: 'none',
+        tilt: false,
+        magnify: 1.006
+      })
+      initializedTargets.add(targetId)
+      if (dynamicSelector) liquidGL.registerDynamic(dynamicSelector)
+    }, 80)
+
+    return () => window.clearTimeout(timer)
+  }, [dynamicSelector, snapshotSelector, targetId])
+
+  return (
+    <div className={`webgl-liquid-glass ${className}`.trim()} style={style}>
+      <div id={targetId} className="webgl-liquid-glass__lens" aria-hidden="true" />
+      <div className="webgl-liquid-glass__content">{children}</div>
+    </div>
+  )
+}

--- a/skills/build-webgl-liquid-glass/assets/react/liquid-gl.d.ts
+++ b/skills/build-webgl-liquid-glass/assets/react/liquid-gl.d.ts
@@ -1,0 +1,27 @@
+declare module 'liquid-gl' {
+  interface LiquidGLOptions {
+    target: string
+    snapshot?: string
+    resolution?: number
+    refraction?: number
+    aberration?: number
+    bevelDepth?: number
+    bevelWidth?: number
+    frost?: number
+    shadow?: boolean
+    specular?: boolean
+    reveal?: 'none' | 'fade'
+    tilt?: boolean
+    tiltFactor?: number
+    tiltEase?: number
+    magnify?: number
+  }
+
+  interface LiquidGL {
+    (options: LiquidGLOptions): unknown
+    registerDynamic(elements: string | Element[]): void
+  }
+
+  const liquidGL: LiquidGL
+  export default liquidGL
+}

--- a/skills/build-webgl-liquid-glass/assets/react/webgl-liquid-glass.css
+++ b/skills/build-webgl-liquid-glass/assets/react/webgl-liquid-glass.css
@@ -1,0 +1,36 @@
+.webgl-liquid-glass {
+  --glass-radius: 16px;
+  --glass-tint: rgba(255, 255, 255, 0.14);
+  --glass-border: rgba(255, 255, 255, 0.3);
+  --glass-shadow: 0 6px 18px rgba(0, 0, 0, 0.24);
+
+  position: relative;
+  min-height: 86px;
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--glass-radius);
+  background: var(--glass-tint);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.34), var(--glass-shadow);
+  backdrop-filter: blur(8px) saturate(140%);
+}
+
+.webgl-liquid-glass__lens {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.webgl-liquid-glass__content {
+  position: relative;
+  z-index: 2;
+  min-height: inherit;
+  padding: 14px 16px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .webgl-liquid-glass,
+  .webgl-liquid-glass__lens {
+    transition: none !important;
+  }
+}

--- a/skills/build-webgl-liquid-glass/references/tuning.md
+++ b/skills/build-webgl-liquid-glass/references/tuning.md
@@ -1,0 +1,32 @@
+# WebGL Tuning
+
+Source: [naughtyduk/liquidGL](https://github.com/naughtyduk/liquidGL), MIT license.
+
+## Parameter Guide
+
+| Parameter | Start | Change carefully |
+| --- | ---: | --- |
+| `resolution` | `1.5` | Lower to `1` for mobile or several lenses; raise to `2` only after profiling. |
+| `refraction` | `0.007` | Keep below `0.012` for readable product UI. |
+| `aberration` | `0.03` | Keep subtle; high values create colored text-like ghosts. |
+| `bevelDepth` | `0.075` | Controls edge depth and highlight strength. |
+| `bevelWidth` | `0.18` | Increase slightly for large panels, reduce for compact cards. |
+| `frost` | `2.2` | Increase for privacy/readability; reduce to reveal more background detail. |
+| `magnify` | `1.006` | Avoid obvious zoom on operational surfaces. |
+
+## Integration Rules
+
+- Use one visual background as `snapshot`; exclude foreground content and overlays.
+- Keep the target empty and the content in a sibling layer with higher `z-index`.
+- Initialize after images and fonts needed by the snapshot have loaded.
+- Call `liquidGL.registerDynamic(selector)` for animated or replaced backgrounds.
+- Prefer a small number of lenses. Profile GPU use before rendering glass on long lists.
+- Do not enable tilt by default. It adds motion and another stacking layer.
+
+## Failure Signatures
+
+- **Duplicate text:** Content was placed inside the WebGL target. Move it to the sibling overlay.
+- **Detached or stale image:** The snapshot is wrong or dynamic content was not registered.
+- **Black/blank lens:** WebGL or capture failed. Keep the CSS fallback visible and inspect console errors.
+- **Hard color bands:** Reduce refraction/aberration or increase frost.
+- **Lens clips while moving:** Check ancestor overflow and target stacking context.


### PR DESCRIPTION
## Summary

Adds two reusable liquid-glass UI skills:

- `build-webgl-liquid-glass`: the default GPU-refraction workflow using `liquid-gl`
- `build-sdf-liquid-glass`: a lightweight SDF/canvas fallback using `vaso`

Both skills keep foreground content outside the filtered layer, include React/CSS templates, document tuning and failure signatures, and define explicit responsive and accessibility checks.

## Validation

- Both skills pass the repository quality-bar checks for metadata, risk, source, trigger section, examples, and limitations.
- Template components were bundled successfully with esbuild against their real npm dependencies.
- `git diff --check` passes.

Note: the repository-wide strict validator currently reports pre-existing errors across the existing catalog; neither new skill appears in that error output.